### PR TITLE
feat(Core/Spells): refactor setting spell info corrections

### DIFF
--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -212,7 +212,7 @@ class SpellImplicitTargetInfo
 private:
     Targets _target;
 public:
-    SpellImplicitTargetInfo() {}
+    SpellImplicitTargetInfo() : _target(Targets(0)) { }
     SpellImplicitTargetInfo(uint32 target);
 
     bool IsArea() const;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3549,6 +3549,1220 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_2].BasePoints += 30000;
     });
 
+    // Natural shapeshifter
+    ApplySpellFix({ 16834, 16835 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
+    });
+
+    // Ebon Plague
+    ApplySpellFix({ 41013 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags[2] = 0x10;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Parasitic Shadowfiend Passive
+    ApplySpellFix({ 41013 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY; // proc debuff, and summon infinite fiends
+    });
+
+    ApplySpellFix({
+        27892, // To Anchor 1
+        27928, // To Anchor 1
+        27935, // To Anchor 1
+        27915, // Anchor to Skulls
+        27931, // Anchor to Skulls
+        27937  // Anchor to Skulls
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
+    });
+
+    // target allys instead of enemies, target A is src_caster, spells with effect like that have ally target
+    // this is the only known exception, probably just wrong data
+    ApplySpellFix({
+        29214, // Wrath of the Plaguebringer
+        54836  // Wrath of the Plaguebringer
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+    });
+
+    // Wind Shear - improper data for EFFECT_1 in 3.3.5 DBC, but is correct in 4.x
+    ApplySpellFix({ 57994 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_MODIFY_THREAT_PERCENT;
+        spellInfo->Effects[EFFECT_1].BasePoints = -6; // -5%
+    });
+
+    // Improved Devouring Plague
+    ApplySpellFix({ 63675 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BonusMultiplier = 0;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+
+    ApplySpellFix({
+        8145, // Tremor Totem (instant pulse)
+        6474  // Earthbind Totem (instant pulse)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_START_PERIODIC_AT_APPLY;
+    });
+
+    ApplySpellFix({
+        53241, // Marked for Death (Rank 1)
+        53243, // Marked for Death (Rank 2)
+        53244, // Marked for Death (Rank 3)
+        53245, // Marked for Death (Rank 4)
+        53246  // Marked for Death (Rank 5)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(423937, 276955137, 2049);
+    });
+
+    ApplySpellFix({
+        70728, // Exploit Weakness
+        70840  // Devious Minds
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_PET);
+    });
+
+    // Culling The Herd
+    ApplySpellFix({ 70893 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
+    });
+
+    // Sigil of the Frozen Conscience - change class mask to custom extended flags of Icy Touch
+    // this is done because another spell also uses the same SpellFamilyFlags as Icy Touch
+    // SpellFamilyFlags[0] & 0x00000040 in SPELLFAMILY_DEATHKNIGHT is currently unused (3.3.5a)
+    // this needs research on modifier applying rules, does not seem to be in Attributes fields
+    ApplySpellFix({ 54800 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000040, 0x00000000, 0x00000000);
+    });
+
+    // Idol of the Flourishing Life
+    ApplySpellFix({ 64949 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000000, 0x02000000, 0x00000000);
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+    });
+
+    ApplySpellFix({
+        34231, // Libram of the Lightbringer
+        60792, // Libram of Tolerance
+        64956  // Libram of the Resolute
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x80000000, 0x00000000, 0x00000000);
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+    });
+
+    ApplySpellFix({
+        28851, // Libram of Light
+        28853, // Libram of Divinity
+        32403  // Blessed Book of Nagrand
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x40000000, 0x00000000, 0x00000000);
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+    });
+
+    // Ride Carpet
+    ApplySpellFix({ 45602 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 0; // force seat 0, vehicle doesn't have the required seat flags for "no seat specified (-1)"
+    });
+
+    ApplySpellFix({
+        64745, // Item - Death Knight T8 Tank 4P Bonus
+        64936  // Item - Warrior T8 Protection 4P Bonus
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 100; // 100% chance of procc'ing, not -10% (chance calculated in PrepareTriggersExecutedOnHit)
+    });
+
+    // Easter Lay Noblegarden Egg Aura - Interrupt flags copied from aura which this aura is linked with
+    ApplySpellFix({ 61719 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
+    });
+
+    // Spell for item The Flag of Ownership (38578)
+    ApplySpellFix({ 51640 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // The Beast Within
+    ApplySpellFix({ 34471 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_CONFUSED | SPELL_ATTR5_USABLE_WHILE_FEARED | SPELL_ATTR5_USABLE_WHILE_STUNNED;
+    });
+
+    // Introspection
+    ApplySpellFix({ 40055, 40165, 40166, 40167 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+    });
+
+    // Minor Fortitude
+    ApplySpellFix({ 2378 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ManaCost = 0;
+        spellInfo->ManaPerSecond = 0;
+    });
+
+    // Threatening Gaze
+    ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_JUMP;
+    });
+
+    /////////////////////////////////////////////
+    /////////////////CLASS SPELLS////////////////
+    /////////////////////////////////////////////
+
+    /////////////////////////////////
+    ///// PALADIN
+    /////////////////////////////////
+    
+    // Heart of the Crusader
+    ApplySpellFix({ 20335, 20336, 20337 }, [](SpellInfo* spellInfo)
+    {
+        if (spellInfo->Id == 20335)
+            spellInfo->Effects[EFFECT_0].TriggerSpell = 21183;
+        else if (spellInfo->Id == 20336)
+            spellInfo->Effects[EFFECT_0].TriggerSpell = 54498;
+        else
+            spellInfo->Effects[EFFECT_0].TriggerSpell = 54499;
+        
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
+    });
+
+    // Bleh, need to change FamilyFlags :/ (have the same as original aura - bad!)
+    ApplySpellFix({ 63510 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags[0] = 0;
+        spellInfo->SpellFamilyFlags[2] = 0x4000000;
+    });
+
+    ApplySpellFix({ 63514 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags[0] = 0;
+        spellInfo->SpellFamilyFlags[2] = 0x2000000;
+    });
+
+    ApplySpellFix({ 63531 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags[0] = 0;
+        spellInfo->SpellFamilyFlags[2] = 0x8000000;
+    });
+
+    // And affecting spells
+    
+    // Improved Devotion Aura
+    ApplySpellFix({ 20138, 20139, 20140 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
+        spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x2000000;
+    });
+
+    // Improved concentration aura
+    ApplySpellFix({ 20254, 20255, 20256 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
+        spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x4000000;
+        spellInfo->Effects[EFFECT_2].SpellClassMask[0] = 0;
+        spellInfo->Effects[EFFECT_2].SpellClassMask[2] = 0x4000000;
+    });
+
+    // Swift Retribution
+    ApplySpellFix({ 53379, 53484, 53648 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
+        spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
+    });
+
+    // Sanctified Retribution
+    ApplySpellFix({ 31869 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
+        spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
+    });
+
+    // Seal of Light trigger
+    ApplySpellFix({ 20167 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellLevel = 0;
+        spellInfo->BaseLevel = 0;
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    // Light's Beacon, Beacon of Light
+    ApplySpellFix({ 53651 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Hand of Reckoning
+    ApplySpellFix({ 62124 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
+    });
+
+    // Redemption
+    ApplySpellFix({ 7328, 10322, 10324, 20772, 20773, 48949, 48950 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyName = SPELLFAMILY_PALADIN;
+    });
+
+    // hack for seal of light and few spells, judgement consists of few single casts and each of them can proc
+    // some spell, base one has disabled proc flag but those dont have this flag
+    ApplySpellFix({ 20184, 20185, 20186, 68055 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
+    });
+
+    // Blessing of sanctuary stats
+    ApplySpellFix({ 67480 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValue = -1;
+        spellInfo->SpellFamilyName = SPELLFAMILY_UNK1; // allows stacking
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY; // just a marker
+    });
+
+    // Seal of Command trigger
+    ApplySpellFix({ 20424 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
+    });
+
+    ApplySpellFix({ 
+        54968, // Glyph of Holy Light, Damage Class should be magic
+        53652, // Beacon of Light heal, Damage Class should be magic
+        53654  // Beacon of Light heal, Damage Class should be magic
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    /////////////////////////////////
+    ///// HUNTER
+    /////////////////////////////////
+    
+    // Furious Howl
+    ApplySpellFix({ 64491, 64492, 64493, 64494, 64495 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
+    });
+
+    // Call of the Wild
+    ApplySpellFix({ 53434 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
+    // Wild Hunt
+    ApplySpellFix({ 62758, 62762 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY;
+    });
+
+    // Intervene
+    ApplySpellFix({ 3411 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Roar of Sacrifice
+    ApplySpellFix({ 3411 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_SPLIT_DAMAGE_PCT;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ALLY);
+        spellInfo->Effects[EFFECT_1].DieSides = 1;
+        spellInfo->Effects[EFFECT_1].BasePoints = 19;
+        spellInfo->Effects[EFFECT_1].MiscValue = 127; // all schools
+    });
+
+    // Silencing Shot
+    ApplySpellFix({ 34490, 41084, 42671 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0.0f;
+    });
+
+    // Monstrous Bite
+    ApplySpellFix({ 54680, 55495, 55496, 55497, 55498, 55499 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
+    // Hunter's Mark
+    ApplySpellFix({ 1130, 14323, 14324, 14325, 53338 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Cobra Strikes
+    ApplySpellFix({ 53257 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcCharges = 2;
+        spellInfo->StackAmount = 0;
+    });
+
+    // Kill Command
+    ApplySpellFix({ 34027 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcCharges = 0;
+    });
+
+    // Kindred Spirits, damage aura
+    ApplySpellFix({ 57458 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_UNK21;
+    });
+
+    // Chimera Shot - Serpent trigger
+    ApplySpellFix({ 53353 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+
+    // Entrapment trigger
+    ApplySpellFix({ 19185, 64803, 64804 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_SKIP_CHECKCAST_LOS_CHECK;
+    });
+
+    // Improved Stings (Rank 2)
+    ApplySpellFix({ 19465 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
+    // Explosive Shot (trigger)
+    ApplySpellFix({ 53352 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Heart of the Phoenix (triggered)
+    ApplySpellFix({ 54114 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_DISMISS_PET;
+        spellInfo->RecoveryTime = 8 * 60 * IN_MILLISECONDS; // prev 600000
+    });
+
+    /////////////////////////////////
+    ///// ROGUE
+    /////////////////////////////////
+
+    // Master of Subtlety
+    ApplySpellFix({ 31221, 31222, 31223 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyName = SPELLFAMILY_ROGUE;
+    });
+
+    ApplySpellFix({ 
+        31221, // Master of Subtlety triggers
+        58428  // Overkill
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SCRIPT_EFFECT;
+    });
+
+    // Honor Among Thieves
+    ApplySpellFix({ 51698, 51700, 51701 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 51699;
+    });
+
+    // Slice and Dice | Distract
+    ApplySpellFix({ 5171, 6774, 1725 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Envenom
+    ApplySpellFix({ 32645, 32684, 57992, 57993 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Dispel = DISPEL_NONE;
+    });
+
+    // Killing Spree (teleport)
+    ApplySpellFix({ 57840 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100 yards
+    });
+
+    // Killing Spree
+    ApplySpellFix({ 51690 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_NOT_BREAK_STEALTH;
+    });
+
+    /////////////////////////////////
+    ///// DEATH KNIGHT
+    /////////////////////////////////
+
+    // Blood Tap visual cd reset
+    ApplySpellFix({ 47804 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->RuneCostID = 442;
+    });
+
+    // Chains of Ice
+    ApplySpellFix({ 45524 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Impurity
+    ApplySpellFix({ 49220, 49633, 49635, 49636, 49638 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->SpellFamilyName = SPELLFAMILY_DEATHKNIGHT;
+    });
+
+    // Deadly Aggression (Deadly Gladiator's Death Knight Relic, item: 42620)
+    ApplySpellFix({ 60549 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Magic Suppression
+    ApplySpellFix({ 49224, 49610, 49611 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcCharges = 0;
+    });
+
+    // Wandering Plague
+    ApplySpellFix({ 50526 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+        spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Dancing Rune Weapon
+    ApplySpellFix({ 49028 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ProcFlags |= PROC_FLAG_DONE_MELEE_AUTO_ATTACK;
+    });
+
+    // Death and Decay
+    ApplySpellFix({ 52212 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+    });
+
+    // T9 blood plague crit bonus
+    ApplySpellFix({ 67118 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+    
+    // Pestilence
+    ApplySpellFix({ 50842 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Horn of Winter, stacking issues
+    ApplySpellFix({ 57330, 57623 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = 0;
+    });
+
+    // Scourge Strike trigger
+    // Blood-caked Blade - Blood-caked Strike trigger
+    ApplySpellFix({ 70890, 50463 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
+    });
+
+    // Blood Gorged - ARP affect Death Strike and Rune Strike
+    ApplySpellFix({ 61274, 61275, 61276, 61277, 61278 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x1400011, 0x20000000, 0x0);
+    });
+
+    // Death Grip, remove main grip mechanic, leave only effect one
+    // Death Grip, should fix taunt on bosses and not break the pull protection at the same time (no aura provides immunity to grip mechanic)
+    ApplySpellFix({ 49576, 49560 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = 0;
+    });
+
+    // Death Grip Jump Dest
+    ApplySpellFix({ 57604 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Death Pact
+    ApplySpellFix({ 48743 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_CANT_TARGET_SELF;
+    });
+
+    // Raise Ally (trigger)
+    ApplySpellFix({ 46619 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes &= ~SPELL_ATTR0_CANT_CANCEL;
+    });
+
+    // Frost Strike
+    ApplySpellFix({ 49143, 51416, 51417, 51418, 51419, 55268 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_BLOCKABLE_SPELL;
+    });
+
+    // Death Knight T10 Tank 2p Bonus
+    ApplySpellFix({ 70650 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
+    });
+
+    /////////////////////////////////
+    ///// SHAMAN
+    /////////////////////////////////
+
+    // Lightning overload
+    ApplySpellFix({ 45297, 45284 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->CategoryRecoveryTime = 0;
+        spellInfo->RecoveryTime = 0;
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS;
+    });
+
+    // Improved Earth Shield
+    ApplySpellFix({ 51560, 51561 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_DAMAGE;
+    });
+
+    // Tidal Force
+    ApplySpellFix({ 55166, 55198 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
+        spellInfo->ProcCharges = 0;
+    });
+
+    // Healing Stream Totem
+    ApplySpellFix({ 52042 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellLevel = 0;
+        spellInfo->BaseLevel = 0;
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    // Earth Shield
+    ApplySpellFix({ 379 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellLevel = 0;
+        spellInfo->BaseLevel = 0;
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    // Stormstrike
+    ApplySpellFix({ 17364 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Strength of Earth totem effect
+    ApplySpellFix({ 8076, 8162, 8163, 10441, 25362, 25527, 57621, 58646 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
+        spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
+    });
+
+    // Flametongue Totem effect
+    ApplySpellFix({ 52109, 52110, 52111, 52112, 52113, 58651, 58654, 58655 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TargetB = spellInfo->Effects[EFFECT_1].TargetB;
+        spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_1].TargetA;
+    });
+
+    // Sentry Totem
+    ApplySpellFix({ 6495 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
+    });
+
+    // Bind Sight (PT)
+    ApplySpellFix({ 6277 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
+        spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
+        spellInfo->AttributesEx7 |= SPELL_ATTR7_REACTIVATE_AT_RESURRECT; // because it is passive, needs this to be properly removed at death in RemoveAllAurasOnDeath()
+    });
+
+    // Ancestral Awakening Heal
+    ApplySpellFix({ 52752 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+
+    // Heroism
+    ApplySpellFix({ 32182 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 57723; // Exhaustion
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Bloodlust
+    ApplySpellFix({ 2825 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 57724; // Sated
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    /////////////////////////////////
+    ///// WARLOCK
+    /////////////////////////////////
+    
+    // Improved Succubus
+    ApplySpellFix({ 18754, 18755, 18756 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
+    // Unstable Affliction
+    ApplySpellFix({ 31117 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
+    });
+
+    // Shadowflame - trigger
+    ApplySpellFix({ 47960 /*r1*/, 61291 /*r2*/ }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
+    });
+
+    // Curse of Doom - summoned doomguard duration fix
+    ApplySpellFix({ 18662 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6);
+    });
+
+    // Glyph of Voidwalker
+    ApplySpellFix({ 56247 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+        spellInfo->Effects[EFFECT_0].MiscValue = SPELLMOD_EFFECT1;
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x8000000, 0, 0);
+    });
+
+    // Everlasting Affliction
+    ApplySpellFix({ 47201, 47202, 47203, 47204, 47205  }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 2; // add corruption to affected spells
+    });
+
+    // Death's Embrace
+    ApplySpellFix({ 47198, 47199, 47200 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 0x4000; // include Drain Soul
+    });
+
+    // Improved Demonic Tactics
+    ApplySpellFix({ 54347, 54348, 54349 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_0].Effect;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = spellInfo->Effects[EFFECT_0].ApplyAuraName;
+        spellInfo->Effects[EFFECT_1].TargetA = spellInfo->Effects[EFFECT_0].TargetA;
+        spellInfo->Effects[EFFECT_0].MiscValue = SPELLMOD_EFFECT1;
+        spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_EFFECT2;
+    });
+
+    // Rain of Fire (Doomguard)
+    ApplySpellFix({ 42227 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0.0f;
+    });
+
+    // Ritual Enslavement
+    ApplySpellFix({ 22987 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
+    });
+
+    /////////////////////////////////
+    ///// MAGE
+    /////////////////////////////////
+    
+    // Combustion, make this passive
+    ApplySpellFix({ 11129 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Dispel = DISPEL_NONE;
+    });
+
+    // Magic Absorption (nigga stole my code)
+    ApplySpellFix({ 29441, 29444 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellLevel = 0;
+    });
+
+    // Living Bomb
+    ApplySpellFix({ 44461, 55361, 55362 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
+    });
+
+    // Evocation
+    ApplySpellFix({ 12051 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+    });
+
+    // MI Fireblast, WE Frostbolt, MI Frostbolt
+    ApplySpellFix({ 59637, 31707, 72898 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    // Blazing Speed
+    ApplySpellFix({ 31641, 31642 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 31643;
+    });
+
+    // Summon Water Elemental (permanent), treat it as pet
+    ApplySpellFix({ 70908 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SUMMON_PET;
+    });
+
+    // Burnout, trigger
+    ApplySpellFix({ 44450 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_POWER_BURN;
+    });
+
+    // Mirror Image - Summon Spells
+    ApplySpellFix({ 58831, 58833, 58834, 65047 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_CASTER;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
+    });
+
+    // Initialize Images (Mirror Image)
+    ApplySpellFix({ 58836 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
+    });
+
+    // Arcane Blast, can't be dispelled
+    ApplySpellFix({ 36032 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+    });
+
+    // Chilled (frost armor, ice armor proc)
+    ApplySpellFix({ 6136, 7321 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
+    });
+
+    // Mirror Image Frostbolt
+    ApplySpellFix({ 59638 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->SpellFamilyName = SPELLFAMILY_MAGE;
+        spellInfo->SpellFamilyFlags = flag96(0x20, 0x0, 0x0);
+    });
+
+    // Fingers of Frost
+    ApplySpellFix({ 44544 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Dispel = DISPEL_NONE;
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
+        spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(685904631, 1151040, 32); // xinef: removed molten armor
+    });
+
+    // Fingers of Frost visual buff
+    ApplySpellFix({ 74396 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcCharges = 2;
+        spellInfo->StackAmount = 0;
+    });
+
+    /////////////////////////////////
+    ///// WARRIOR
+    /////////////////////////////////
+    
+    // Glyph of blocking
+    ApplySpellFix({ 58375 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 58374;
+    });
+
+    // Sweeping Strikes stance change
+    ApplySpellFix({ 12328 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
+    });
+
+    // Damage Shield
+    ApplySpellFix({ 59653 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->SpellLevel = 0;
+    });
+
+     // Strange shared cooldown
+    ApplySpellFix({ 
+        20230,  // Retaliation
+        871,    // Shield Wall
+        1719    // Recklessness
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_IGNORE_CATEGORY_COOLDOWN_MODS;
+    });
+
+    // Vigilance, fixes bug with empowered renew, single target aura
+    ApplySpellFix({ 50720 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyName = SPELLFAMILY_WARRIOR;
+    });
+
+    // Sunder Armor - trigger, remove spellfamilyflags because of glyph of sunder armor
+    ApplySpellFix({ 58567 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyFlags = flag96(0x0, 0x0, 0x0);
+    });
+
+    // Sunder Armor - Old Ranks
+    ApplySpellFix({ 7405, 8380, 11596, 11597, 25225, 47467 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 11971;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE;
+    });
+    
+    // Improved Spell Reflection
+    ApplySpellFix({ 59725 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_CASTER_AREA_PARTY;
+    });
+    
+    /////////////////////////////////
+    ///// PRIEST
+    /////////////////////////////////
+
+    // Shadow Weaving
+    ApplySpellFix({ 15257, 15331, 15332 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
+    });
+    
+    // Hymn of Hope - rewrite part of aura system or swap effects...
+    ApplySpellFix({ 64904 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT;
+        spellInfo->Effects[EFFECT_2].Effect = spellInfo->Effects[EFFECT_0].Effect;
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+        spellInfo->Effects[EFFECT_0].DieSides = spellInfo->Effects[EFFECT_0].DieSides;
+        spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_0].TargetB;
+        spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
+        spellInfo->Effects[EFFECT_2].BasePoints = spellInfo->Effects[EFFECT_0].BasePoints;
+    });
+
+    // Divine Hymn
+    ApplySpellFix({ 64844 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->SpellLevel = 0;
+    });
+
+    ApplySpellFix({ 
+        // Spiritual Healing affects prayer of mending
+        14898, 15349, 15354, 15355, 15356,             
+        // Divine Providence affects prayer of mending
+        47562, 47564, 47565, 47566, 47567,
+        // Twin Disciplines affects prayer of mending
+        47586, 47587, 47588, 52802, 52803
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].SpellClassMask[1] |= 0x20; // prayer of mending
+    });
+
+    // Power Infusion, hack to fix stacking with arcane power
+    ApplySpellFix({ 10060 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ALLY;
+    });
+
+    /////////////////////////////////
+    ///// DRUID
+    /////////////////////////////////
+    
+    // Lifebloom final bloom
+    ApplySpellFix({ 33778 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->SpellLevel = 0;
+        spellInfo->SpellFamilyFlags = flag96(0, 0x10, 0);
+    });
+    
+    // Clearcasting
+    ApplySpellFix({ 16870 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(31); // 8 secs
+    });
+
+    // Owlkin Frenzy
+    ApplySpellFix({ 48391 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
+    });
+
+    // Item T10 Restoration 4P Bonus
+    ApplySpellFix({ 70691 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+
+    // Faerie Fire, Faerie Fire (Feral)
+    ApplySpellFix({ 770, 16857 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE;
+    });
+
+    // Feral Charge - Cat
+    ApplySpellFix({ 49376, 61138, 61132, 50259 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Glyph of Barkskin
+    ApplySpellFix({ 63058 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE;
+    });
+
+    /////////////////////////////////
+    ///// MISC
+    /////////////////////////////////
+
+    // Resurrection Sickness
+    ApplySpellFix({ 15007 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SpellFamilyName = SPELLFAMILY_GENERIC;
+    });
+
+    // Luck of the Draw
+    ApplySpellFix({ 72221 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
+    // Bind
+    ApplySpellFix({ 3286 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets = 0; // neutral innkeepers not friendly?
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    // Remove creature target type
+    ApplySpellFix({ 2641, 23356 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->TargetCreatureType = 0;
+    });
+
+    // Aspect of the Viper
+    ApplySpellFix({ 34074 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_2].TargetA = 1;
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_DUMMY;
+    });
+
+    // Strength of Wrynn
+    ApplySpellFix({ 60509 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].BasePoints = 1500;
+        spellInfo->Effects[EFFECT_1].BasePoints = 150;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_PERIODIC_HEAL;
+    });
+
+    // Playback Speech
+    ApplySpellFix({ 74209 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);
+    });
+
+    // Winterfin First Responder
+    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 1;
+        spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 0;
+        spellInfo->Effects[EFFECT_0].DieSides = 0;
+        spellInfo->Effects[EFFECT_0].DamageMultiplier = 0;
+        spellInfo->Effects[EFFECT_0].BonusMultiplier = 0;
+    });
+
+    // Army of the Dead (trigger npc aura)
+    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Amplitude = 15000;
+    });
+
+    // Isle of Conquest - Teleport in, missing range
+    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 50000yd
+    });
+
+    // A'dal's Song of Battle
+    ApplySpellFix({ 39953 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(367); // 2 Hours
+    });
+
+    // Wintergrasp spells
+    ApplySpellFix({ 
+        57607, // Wintergrasp Catapult - Spell Plague Barrel - EffectRadiusIndex
+        57619, // Wintergrasp Demolisher - Spell Hourl Boulder - EffectRadiusIndex
+        57610  // Cannon (Siege Turret)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS); // SPELL_EFFECT_WMO_DAMAGE
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
+    });
+
+    // WintergraspCannon - Spell Fire Cannon - EffectRadiusIndex
+    ApplySpellFix({ 51422 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
+    });
+
+    // WintergraspDemolisher - Spell Ram -  EffectRadiusIndex
+    ApplySpellFix({ 54107 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_KNOCK_BACK
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
+        spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_WEAPON_DAMAGE
+    });
+
+    // WintergraspSiegeEngine - Spell Ram - EffectRadiusIndex
+    ApplySpellFix({ 51678 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_KNOCK_BACK
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
+        spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS); // SPELL_EFFECT_WEAPON_DAMAGE
+    });
+
+    // WintergraspCatapult - Spell Plague Barrell - Range
+    ApplySpellFix({ 57606 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(164); // "Catapult Range"
+    });
+
+    // Boulder (Demolisher)
+    ApplySpellFix({ 50999 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13); // 10yd
+    });
+
+    // Flame Breath (Catapult)
+    ApplySpellFix({ 50990 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(19); // 18yd
+    });
+
+    // Jormungar Bite
+    ApplySpellFix({ 50990 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_TARGET_ENEMY;
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+    
+    /////////////////////////////////
+    ///// Generic NPC Spells
+    /////////////////////////////////
+
+    // Throw Proximity Bomb
+    ApplySpellFix({ 34095 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_TARGET_ENEMY;
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    ApplySpellFix({ 
+        53348, // DEATH KNIGHT SCARLET FIRE ARROW
+        53117  // BALISTA
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RecoveryTime = 5000;
+        spellInfo->CategoryRecoveryTime = 5000;
+    });
+    
+    // Teleport To Molten Core
+    ApplySpellFix({ 25139 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
+    });
+
+    // ///////////////////////////////////////////
+    // ////////////////BOSS SPELLS////////////////
+    // ///////////////////////////////////////////
+
+    //////////////////////////////////////////
+    ////////// Vanilla Instances
+    //////////////////////////////////////////
+
+    // Shadowfang Keep
+    // Landen Stilwell Transform
+    ApplySpellFix({ 31310 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
+    });
+
+    
     for (auto spellInfo : mSpellInfoMap)
     {
         for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
@@ -3584,993 +4798,6 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         switch (spellInfo->Id)
         {
-            case 16834: // Natural shapeshifter
-            case 16835:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
-                break;
-            case 51735: // Ebon Plague
-            case 51734:
-            case 51726:
-                spellInfo->SpellFamilyFlags[2] = 0x10;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            case 41013: // Parasitic Shadowfiend Passive
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY; // proc debuff, and summon infinite fiends
-                break;
-            case 27892: // To Anchor 1
-            case 27928: // To Anchor 1
-            case 27935: // To Anchor 1
-            case 27915: // Anchor to Skulls
-            case 27931: // Anchor to Skulls
-            case 27937: // Anchor to Skulls
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
-                break;
-            // target allys instead of enemies, target A is src_caster, spells with effect like that have ally target
-            // this is the only known exception, probably just wrong data
-            case 29214: // Wrath of the Plaguebringer
-            case 54836: // Wrath of the Plaguebringer
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                break;
-            case 57994: // Wind Shear - improper data for EFFECT_1 in 3.3.5 DBC, but is correct in 4.x
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_MODIFY_THREAT_PERCENT;
-                spellInfo->Effects[EFFECT_1].BasePoints = -6; // -5%
-                break;
-            case 63675: // Improved Devouring Plague
-                spellInfo->Effects[EFFECT_0].BonusMultiplier = 0;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            case 8145: // Tremor Totem (instant pulse)
-            case 6474: // Earthbind Totem (instant pulse)
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_START_PERIODIC_AT_APPLY;
-                break;
-            case 53241: // Marked for Death (Rank 1)
-            case 53243: // Marked for Death (Rank 2)
-            case 53244: // Marked for Death (Rank 3)
-            case 53245: // Marked for Death (Rank 4)
-            case 53246: // Marked for Death (Rank 5)
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(423937, 276955137, 2049);
-                break;
-            case 70728: // Exploit Weakness
-            case 70840: // Devious Minds
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_PET);
-                break;
-            case 70893: // Culling The Herd
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
-                break;
-            case 54800: // Sigil of the Frozen Conscience - change class mask to custom extended flags of Icy Touch
-                // this is done because another spell also uses the same SpellFamilyFlags as Icy Touch
-                // SpellFamilyFlags[0] & 0x00000040 in SPELLFAMILY_DEATHKNIGHT is currently unused (3.3.5a)
-                // this needs research on modifier applying rules, does not seem to be in Attributes fields
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000040, 0x00000000, 0x00000000);
-                break;
-            case 64949: // Idol of the Flourishing Life
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000000, 0x02000000, 0x00000000);
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-                break;
-            case 34231: // Libram of the Lightbringer
-            case 60792: // Libram of Tolerance
-            case 64956: // Libram of the Resolute
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x80000000, 0x00000000, 0x00000000);
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-                break;
-            case 28851: // Libram of Light
-            case 28853: // Libram of Divinity
-            case 32403: // Blessed Book of Nagrand
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x40000000, 0x00000000, 0x00000000);
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-                break;
-            case 45602: // Ride Carpet
-                spellInfo->Effects[EFFECT_0].BasePoints = 0; // force seat 0, vehicle doesn't have the required seat flags for "no seat specified (-1)"
-                break;
-            case 64745: // Item - Death Knight T8 Tank 4P Bonus
-            case 64936: // Item - Warrior T8 Protection 4P Bonus
-                spellInfo->Effects[EFFECT_0].BasePoints = 100; // 100% chance of procc'ing, not -10% (chance calculated in PrepareTriggersExecutedOnHit)
-                break;
-            case 61719: // Easter Lay Noblegarden Egg Aura - Interrupt flags copied from aura which this aura is linked with
-                spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
-                break;
-            case 51640: // spell for item The Flag of Ownership (38578)
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-            case 34471: // The Beast Within
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_CONFUSED | SPELL_ATTR5_USABLE_WHILE_FEARED | SPELL_ATTR5_USABLE_WHILE_STUNNED;
-                break;
-            case 40055: // Introspection
-            case 40165: // Introspection
-            case 40166: // Introspection
-            case 40167: // Introspection
-                spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
-                break;
-            case 2378: // Minor Fortitude
-                spellInfo->ManaCost = 0;
-                spellInfo->ManaPerSecond = 0;
-                break;
-            case 24314: // Threatening Gaze
-                spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_JUMP;
-                break;
-
-
-            /////////////////////////////////////////////
-            /////////////////CLASS SPELLS////////////////
-            /////////////////////////////////////////////
-
-            /////////////////////////////////
-            ///// PALADIN
-            /////////////////////////////////
-            // Heart of the Crusader
-            case 20335:
-            case 20336:
-            case 20337:
-                if (spellInfo->Id == 20335)
-                    spellInfo->Effects[EFFECT_0].TriggerSpell = 21183;
-                else if (spellInfo->Id == 20336)
-                    spellInfo->Effects[EFFECT_0].TriggerSpell = 54498;
-                else
-                    spellInfo->Effects[EFFECT_0].TriggerSpell = 54499;
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
-                break;
-            // Bleh, need to change FamilyFlags :/ (have the same as original aura - bad!)
-            case 63510:
-                spellInfo->SpellFamilyFlags[0] = 0;
-                spellInfo->SpellFamilyFlags[2] = 0x4000000;
-                break;
-            case 63514:
-                spellInfo->SpellFamilyFlags[0] = 0;
-                spellInfo->SpellFamilyFlags[2] = 0x2000000;
-                break;
-            case 63531:
-                spellInfo->SpellFamilyFlags[0] = 0;
-                spellInfo->SpellFamilyFlags[2] = 0x8000000;
-                break;
-            // And affecting spells
-            case 20138:
-            case 20139:
-            case 20140:// Improved Devotion Aura
-                spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
-                spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x2000000;
-                break;
-            case 20254:
-            case 20255:
-            case 20256:// Improved concentration aura
-                spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
-                spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x4000000;
-                spellInfo->Effects[EFFECT_2].SpellClassMask[0] = 0;
-                spellInfo->Effects[EFFECT_2].SpellClassMask[2] = 0x4000000;
-                break;
-            case 53379:
-            case 53484:
-            case 53648:// Swift Retribution
-                spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
-                spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
-                break;
-            case 31869:// Sanctified Retribution
-                spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
-                spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
-                break;
-            /* Judgements Facing   -- SCEICCO: not sure this is offylike
-            case 20271:
-            case 53407:
-            case 53408:
-                spellInfo->FacingCasterFlags |= SPELL_FACING_FLAG_INFRONT;
-                break;*/
-            // Seal of Light trigger
-            case 20167:
-                spellInfo->SpellLevel = 0;
-                spellInfo->BaseLevel = 0;
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                break;
-            // Light's Beacon, Beacon of Light
-            case 53651:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Hand of Reckoning
-            case 62124:
-                spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
-                break;
-            // Redemption
-            case 7328:
-            case 10322:
-            case 10324:
-            case 20772:
-            case 20773:
-            case 48949:
-            case 48950:
-                spellInfo->SpellFamilyName = SPELLFAMILY_PALADIN;
-                break;
-            // hack for seal of light and few spells, judgement consists of few single casts and each of them can proc
-            // some spell, base one has disabled proc flag but those dont have this flag
-            case 20184:
-            case 20185:
-            case 20186:
-            case 68055:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
-                break;
-            // Blessing of sanctuary stats
-            case 67480:
-                spellInfo->Effects[EFFECT_0].MiscValue = -1;
-                spellInfo->SpellFamilyName = SPELLFAMILY_UNK1; // allows stacking
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY; // just a marker
-                break;
-            // Seal of Command trigger
-            case 20424:
-                spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
-                break;
-            // Glyph of Holy Light, Damage Class should be magic
-            case 54968:
-            // Beacon of Light heal, Damage Class should be magic
-            case 53652:
-            case 53654:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                break;
-
-
-            /////////////////////////////////
-            ///// HUNTER
-            /////////////////////////////////
-            // Furious Howl
-            case 64491:
-            case 64492:
-            case 64493:
-            case 64494:
-            case 64495:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
-                break;
-            // Call of the Wild
-            case 53434:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                break;
-            // Wild Hunt
-            case 62758:
-            case 62762:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY;
-                break;
-            // Intervene
-            case 3411:
-                spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Roar of Sacrifice
-            case 53480:
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_SPLIT_DAMAGE_PCT;
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ALLY);
-                spellInfo->Effects[EFFECT_1].DieSides = 1;
-                spellInfo->Effects[EFFECT_1].BasePoints = 19;
-                spellInfo->Effects[EFFECT_1].MiscValue = 127; // all schools
-                break;
-            // Silencing Shot
-            case 34490:
-            case 41084:
-            case 42671:
-                spellInfo->Speed = 0.0f;
-                break;
-            // Monstrous Bite
-            case 54680:
-            case 55495:
-            case 55496:
-            case 55497:
-            case 55498:
-            case 55499:
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                break;
-            // Hunter's Mark
-            case 1130:
-            case 14323:
-            case 14324:
-            case 14325:
-            case 53338:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            // Cobra Strikes
-            case 53257:
-                spellInfo->ProcCharges = 2;
-                spellInfo->StackAmount = 0;
-                break;
-            // Kill Command
-            case 34027:
-                spellInfo->ProcCharges = 0;
-                break;
-            // Kindred Spirits, damage aura
-            case 57458:
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_UNK21;
-                break;
-            // Chimera Shot - Serpent trigger
-            case 53353:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            // Entrapment trigger
-            case 19185:
-            case 64803:
-            case 64804:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_SKIP_CHECKCAST_LOS_CHECK;
-                break;
-            // Improved Stings (Rank 2)
-            case 19465:
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                break;
-            // Explosive Shot (trigger)
-            case 53352:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            // Heart of the Phoenix (triggered)
-            case 54114:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_DISMISS_PET;
-                spellInfo->RecoveryTime = 8 * 60 * IN_MILLISECONDS; // prev 600000
-                break;
-
-            /////////////////////////////////
-            ///// ROGUE
-            /////////////////////////////////
-            // Master of Subtlety
-            case 31221:
-            case 31222:
-            case 31223:
-                spellInfo->SpellFamilyName = SPELLFAMILY_ROGUE;
-                break;
-            // Master of Subtlety triggers
-            case 31666:
-            // Overkill
-            case 58428:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SCRIPT_EFFECT;
-                break;
-            // Honor Among Thieves
-            case 51698:
-            case 51700:
-            case 51701:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 51699;
-                break;
-            // Slice and Dice
-            case 5171:
-            case 6774:
-            // Distract
-            case 1725:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Envenom
-            case 32645:
-            case 32684:
-            case 57992:
-            case 57993:
-                spellInfo->Dispel = DISPEL_NONE;
-                break;
-            // Killing Spree (teleport)
-            case 57840:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100 yards
-                break;
-            // Killing Spree
-            case 51690:
-                spellInfo->AttributesEx |= SPELL_ATTR1_NOT_BREAK_STEALTH;
-                break;
-
-
-            /////////////////////////////////
-            ///// DEATH KNIGHT
-            /////////////////////////////////
-            // Blood Tap visual cd reset
-            case 47804:
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->RuneCostID = 442;
-                break;
-            // Chains of Ice
-            case 45524:
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            // Impurity
-            case 49220:
-            case 49633:
-            case 49635:
-            case 49636:
-            case 49638:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->SpellFamilyName = SPELLFAMILY_DEATHKNIGHT;
-                break;
-            // Deadly Aggression (Deadly Gladiator's Death Knight Relic, item: 42620)
-            case 60549:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            // Magic Suppression
-            case 49224:
-            case 49610:
-            case 49611:
-                spellInfo->ProcCharges = 0;
-                break;
-            // Wandering Plague
-            case 50526:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Dancing Rune Weapon
-            case 49028:
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                spellInfo->ProcFlags |= PROC_FLAG_DONE_MELEE_AUTO_ATTACK;
-                break;
-            // Death and Decay
-            case 52212:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
-                break;
-            // T9 blood plague crit bonus
-            case 67118:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            // Pestilence
-            case 50842:
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_DEST_TARGET_ENEMY;
-                break;
-            // Horn of Winter, stacking issues
-            case 57330:
-            case 57623:
-                spellInfo->Effects[EFFECT_1].TargetA = 0;
-                break;
-            // Scourge Strike trigger
-            case 70890:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
-                break;
-            // Blood-caked Blade - Blood-caked Strike trigger
-            case 50463:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
-                break;
-            // Blood Gorged - ARP affect Death Strike and Rune Strike
-            case 61274:
-            case 61275:
-            case 61276:
-            case 61277:
-            case 61278:
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x1400011, 0x20000000, 0x0);
-                break;
-            // Death Grip, remove main grip mechanic, leave only effect one
-            // Death Grip, should fix taunt on bosses and not break the pull protection at the same time (no aura provides immunity to grip mechanic)
-            case 49576:
-            case 49560:
-                spellInfo->Mechanic = 0;
-                break;
-            // Death Grip Jump Dest
-            case 57604:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // Death Pact
-            case 48743:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_CANT_TARGET_SELF;
-                break;
-            // Raise Ally (trigger)
-            case 46619:
-                spellInfo->Attributes &= ~SPELL_ATTR0_CANT_CANCEL;
-                break;
-            // Frost Strike
-            case 49143:
-            case 51416:
-            case 51417:
-            case 51418:
-            case 51419:
-            case 55268:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_BLOCKABLE_SPELL;
-                break;
-            // Death Knight T10 Tank 2p Bonus
-            case 70650:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
-                break;
-
-
-
-            /////////////////////////////////
-            ///// SHAMAN
-            /////////////////////////////////
-            // Lightning overload
-            case 45297:
-            case 45284:
-                spellInfo->CategoryRecoveryTime = 0;
-                spellInfo->RecoveryTime = 0;
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_LIMIT_PCT_DAMAGE_MODS;
-                break;
-            // Improved Earth Shield
-            case 51560:
-            case 51561:
-                spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_DAMAGE;
-                break;
-            // Tidal Force
-            case 55166:
-            case 55198:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
-                spellInfo->ProcCharges = 0;
-                break;
-            // Healing Stream Totem
-            case 52042:
-                spellInfo->SpellLevel = 0;
-                spellInfo->BaseLevel = 0;
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                break;
-            // Earth Shield
-            case 379:
-                spellInfo->SpellLevel = 0;
-                spellInfo->BaseLevel = 0;
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            // Stormstrike
-            case 17364:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Strength of Earth totem effect
-            case 8076:
-            case 8162:
-            case 8163:
-            case 10441:
-            case 25362:
-            case 25527:
-            case 57621:
-            case 58646:
-                spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
-                spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
-                break;
-            // Flametongue Totem effect
-            case 52109:
-            case 52110:
-            case 52111:
-            case 52112:
-            case 52113:
-            case 58651:
-            case 58654:
-            case 58655:
-                spellInfo->Effects[EFFECT_2].TargetB = spellInfo->Effects[EFFECT_1].TargetB;
-                spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_1].TargetA;
-                break;
-            // Sentry Totem
-            case 6495:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
-                break;
-            // Bind Sight (PT)
-            case 6277:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
-                spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
-                spellInfo->AttributesEx7 |= SPELL_ATTR7_REACTIVATE_AT_RESURRECT; // because it is passive, needs this to be properly removed at death in RemoveAllAurasOnDeath()
-                break;
-            // Ancestral Awakening Heal
-            case 52752:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            case 32182: // Heroism
-                spellInfo->ExcludeTargetAuraSpell = 57723; // Exhaustion
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            case 2825:  // Bloodlust
-                spellInfo->ExcludeTargetAuraSpell = 57724; // Sated
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-
-            /////////////////////////////////
-            ///// WARLOCK
-            /////////////////////////////////
-            // Improved Succubus
-            case 18754:
-            case 18755:
-            case 18756:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                break;
-            // Unstable Affliction
-            case 31117:
-                spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
-                break;
-            // Shadowflame - trigger
-            case 47960: // r1
-            case 61291: // r2
-                spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
-                break;
-            // Curse of Doom - summoned doomguard duration fix
-            case 18662:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6);
-                break;
-            // Glyph of Voidwalker
-            case 56247:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-                spellInfo->Effects[EFFECT_0].MiscValue = SPELLMOD_EFFECT1;
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x8000000, 0, 0);
-                break;
-            // Everlasting Affliction
-            case 47201:
-            case 47202:
-            case 47203:
-            case 47204:
-            case 47205:
-                spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 2; // add corruption to affected spells
-                break;
-            // Death's Embrace
-            case 47198:
-            case 47199:
-            case 47200:
-                spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 0x4000; // include Drain Soul
-                break;
-            // Improved Demonic Tactics
-            case 54347:
-            case 54348:
-            case 54349:
-                spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_0].Effect;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = spellInfo->Effects[EFFECT_0].ApplyAuraName;
-                spellInfo->Effects[EFFECT_1].TargetA = spellInfo->Effects[EFFECT_0].TargetA;
-                spellInfo->Effects[EFFECT_0].MiscValue = SPELLMOD_EFFECT1;
-                spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_EFFECT2;
-                break;
-            // Rain of Fire (Doomguard)
-            case 42227:
-                spellInfo->Speed = 0.0f;
-                break;
-            // Ritual Enslavement
-            case 22987:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
-                break;
-
-
-            /////////////////////////////////
-            ///// MAGE
-            /////////////////////////////////
-            // Combustion, make this passive
-            case 11129:
-                spellInfo->Dispel = DISPEL_NONE;
-                break;
-            // Magic Absorption (nigga stole my code)
-            case 29441:
-            case 29444:
-                spellInfo->SpellLevel = 0;
-                break;
-            // Living Bomb
-            case 44461:
-            case 55361:
-            case 55362:
-                spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
-                break;
-            // Evocation
-            case 12051:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                break;
-            // MI Fireblast, WE Frostbolt, MI Frostbolt
-            case 59637:
-            case 31707:
-            case 72898:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                break;
-            // Blazing Speed
-            case 31641:
-            case 31642:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 31643;
-                break;
-            // Summon Water Elemental (permanent), treat it as pet
-            case 70908:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SUMMON_PET;
-                break;
-            // Burnout, trigger
-            case 44450:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_POWER_BURN;
-                break;
-            // Mirror Image - Summon Spells
-            case 58831:
-            case 58833:
-            case 58834:
-            case 65047:
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_CASTER;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
-                break;
-            // Initialize Images (Mirror Image)
-            case 58836:
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
-                break;
-            // Arcane Blast, can't be dispelled
-            case 36032:
-                spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                break;
-            // Chilled (frost armor, ice armor proc)
-            case 6136:
-            case 7321:
-                spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
-                break;
-            // Mirror Image Frostbolt
-            case 59638:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->SpellFamilyName = SPELLFAMILY_MAGE;
-                spellInfo->SpellFamilyFlags = flag96(0x20, 0x0, 0x0);
-                break;
-            // Fingers of Frost
-            case 44544:
-                spellInfo->Dispel = DISPEL_NONE;
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
-                spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(685904631, 1151040, 32); // xinef: removed molten armor
-                break;
-            // Fingers of Frost visual buff
-            case 74396:
-                spellInfo->ProcCharges = 2;
-                spellInfo->StackAmount = 0;
-                break;
-
-
-            /////////////////////////////////
-            ///// WARRIOR
-            /////////////////////////////////
-            // Glyph of blocking
-            case 58375:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 58374;
-                break;
-            // Sweeping Strikes stance change
-            case 12328:
-                spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
-                break;
-            // Damage Shield
-            case 59653:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->SpellLevel = 0;
-                break;
-            // Strange shared cooldown
-            case 20230: // Retaliation
-            case 871: // Shield Wall
-            case 1719: // Recklessness
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_IGNORE_CATEGORY_COOLDOWN_MODS;
-                break;
-            // Vigilance, fixes bug with empowered renew, single target aura
-            case 50720:
-                spellInfo->SpellFamilyName = SPELLFAMILY_WARRIOR;
-                break;
-            // Sunder Armor - trigger, remove spellfamilyflags because of glyph of sunder armor
-            case 58567:
-                spellInfo->SpellFamilyFlags = flag96(0x0, 0x0, 0x0);
-                break;
-            // Sunder Armor - Old Ranks
-            case 7405:
-            case 8380:
-            case 11596:
-            case 11597:
-            case 25225:
-            case 47467:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 11971;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE;
-                break;
-            // Improved Spell Reflection
-            case 59725:
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_CASTER_AREA_PARTY;
-                break;
-
-
-
-            /////////////////////////////////
-            ///// PRIEST
-            /////////////////////////////////
-            // Shadow Weaving
-            case 15257:
-            case 15331:
-            case 15332:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
-                break;
-            // Hymn of Hope - rewrite part of aura system or swap effects...
-            case 64904:
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT;
-                spellInfo->Effects[EFFECT_2].Effect = spellInfo->Effects[EFFECT_0].Effect;
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                spellInfo->Effects[EFFECT_0].DieSides = spellInfo->Effects[EFFECT_0].DieSides;
-                spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_0].TargetB;
-                spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
-                spellInfo->Effects[EFFECT_2].BasePoints = spellInfo->Effects[EFFECT_0].BasePoints;
-                break;
-            // Divine Hymn
-            case 64844:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->SpellLevel = 0;
-                break;
-            // Spiritual Healing affects prayer of mending
-            case 14898:
-            case 15349:
-            case 15354:
-            case 15355:
-            case 15356:
-            // Divine Providence affects prayer of mending
-            case 47562:
-            case 47564:
-            case 47565:
-            case 47566:
-            case 47567:
-            // Twin Disciplines affects prayer of mending
-            case 47586:
-            case 47587:
-            case 47588:
-            case 52802:
-            case 52803:
-                spellInfo->Effects[EFFECT_0].SpellClassMask[1] |= 0x20; // prayer of mending
-                break;
-            // Power Infusion, hack to fix stacking with arcane power
-            case 10060:
-                spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ALLY;
-                break;
-
-            /////////////////////////////////
-            ///// DRUID
-            /////////////////////////////////
-            // Lifebloom final bloom
-            case 33778:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->SpellLevel = 0;
-                spellInfo->SpellFamilyFlags = flag96(0, 0x10, 0);
-                break;
-            // Clearcasting
-            case 16870:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(31); // 8 secs
-                break;
-            // Owlkin Frenzy
-            case 48391:
-                spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
-                break;
-            // Item T10 Restoration 4P Bonus
-            case 70691:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            // Faerie Fire, Faerie Fire (Feral)
-            case 770:
-            case 16857:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE;
-                break;
-            // Feral Charge - Cat
-            case 49376:
-            case 61138:
-            case 61132:
-            case 50259:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Glyph of Barkskin
-            case 63058:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE;
-                break;
-
-
-            /////////////////////////////////
-            ///// MISC
-            /////////////////////////////////
-            // Resurrection Sickness
-            case 15007:
-                spellInfo->SpellFamilyName = SPELLFAMILY_GENERIC;
-                break;
-            // Luck of the Draw
-            case 72221:
-                spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
-                break;
-            case 3286:  // Bind
-                spellInfo->Targets = 0; // neutral innkeepers not friendly?
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            // remove creaturetargettype
-            case 2641:
-            case 23356:
-                spellInfo->TargetCreatureType = 0;
-                break;
-            case 34074: // Aspect of the Viper
-                spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_2].TargetA = 1;
-                spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_DUMMY;
-                break;
-            // Strength of Wrynn
-            case 60509:
-                spellInfo->Effects[EFFECT_2].BasePoints = 1500;
-                spellInfo->Effects[EFFECT_1].BasePoints = 150;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_PERIODIC_HEAL;
-                break;
-            // Playback Speech
-            case 74209:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);
-                break;
-            // Winterfin First Responder
-            case 48739:
-                spellInfo->Effects[EFFECT_0].BasePoints = 1;
-                spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 0;
-                spellInfo->Effects[EFFECT_0].DieSides = 0;
-                spellInfo->Effects[EFFECT_0].DamageMultiplier = 0;
-                spellInfo->Effects[EFFECT_0].BonusMultiplier = 0;
-                break;
-            // Army of the Dead (trigger npc aura)
-            case 49099:
-                spellInfo->Effects[EFFECT_0].Amplitude = 15000;
-                break;
-            // Isle of Conquest - Teleport in, missing range
-            case 66551:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 50000yd
-                break;
-            // A'dal's Song of Battle
-            case 39953:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(367); // 2 Hours
-                break;
-            // Wintergrasp spells
-            case 57607: // WintergraspCatapult - Spell Plague Barrel - EffectRadiusIndex
-            case 57619: // WintergraspDemolisher - Spell Hourl Boulder - EffectRadiusIndex
-            case 57610: // Cannon (Siege Turret)
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS); // SPELL_EFFECT_WMO_DAMAGE
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 51422: // WintergraspCannon - Spell Fire Cannon - EffectRadiusIndex
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
-                break;
-            case 54107: // WintergraspDemolisher - Spell Ram -  EffectRadiusIndex
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_KNOCK_BACK
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
-                spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_WEAPON_DAMAGE
-                break;
-            case 51678: // WintergraspSiegeEngine - Spell Ram - EffectRadiusIndex
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_KNOCK_BACK
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
-                spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS); // SPELL_EFFECT_WEAPON_DAMAGE
-                break;
-            case 57606: // WintergraspCatapult - Spell Plague Barrell - Range
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(164); // "Catapult Range"
-                break;
-            case 50999: // Boulder (Demolisher)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13); // 10yd
-                break;
-            case 50990: // Flame Breath (Catapult)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(19); // 18yd
-                break;
-            case 56103: // Jormungar Bite
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_TARGET_ENEMY;
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-
-            /////////////////////////////////
-            ///// Generic NPC Spells
-            /////////////////////////////////
-
-            // Throw Proximity Bomb
-            case 34095:
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_TARGET_ENEMY;
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // DEATH KNIGHT SCARLET FIRE ARROW
-            case 53348:
-            // BALISTA
-            case 53117:
-                spellInfo->RecoveryTime = 5000;
-                spellInfo->CategoryRecoveryTime = 5000;
-                break;
-            // Teleport To Molten Core
-            case 25139:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
-                break;
-
-
-            // ///////////////////////////////////////////
-            // ////////////////BOSS SPELLS////////////////
-            // ///////////////////////////////////////////
-            //////////////////////////////////////////
-            ////////// Vanilla Instances
-            //////////////////////////////////////////
-
-            // Shadowfang Keep
-            // Landen Stilwell Transform
-            case 31310:
-                spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
-                break;
-
             // Blackfathom Deeps
             // Shadowstalker Stealth
             case 5916:

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3915,7 +3915,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Roar of Sacrifice
-    ApplySpellFix({ 3411 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 53480 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_SPLIT_DAMAGE_PCT;
@@ -4088,7 +4088,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 50526 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-        spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Dancing Rune Weapon
@@ -4114,7 +4114,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Pestilence
     ApplySpellFix({ 50842 }, [](SpellInfo * spellInfo)
     {
-        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
     });
 
     // Horn of Winter, stacking issues
@@ -4212,6 +4212,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->SpellLevel = 0;
         spellInfo->BaseLevel = 0;
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
     // Stormstrike
@@ -4230,8 +4231,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Flametongue Totem effect
     ApplySpellFix({ 52109, 52110, 52111, 52112, 52113, 58651, 58654, 58655 }, [](SpellInfo * spellInfo)
     {
-        spellInfo->Effects[EFFECT_2].TargetB = spellInfo->Effects[EFFECT_1].TargetB;
-        spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_1].TargetA;
+        spellInfo->Effects[EFFECT_2].TargetB = spellInfo->Effects[EFFECT_1].TargetB = spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_1].TargetA = spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Sentry Totem
@@ -4305,7 +4306,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Everlasting Affliction
-    ApplySpellFix({ 47201, 47202, 47203, 47204, 47205  }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 47201, 47202, 47203, 47204, 47205 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 2; // add corruption to affected spells
     });
@@ -4357,7 +4358,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Living Bomb
     ApplySpellFix({ 44461, 55361, 55362 }, [](SpellInfo * spellInfo)
     {
-        spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
         spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
     });
 
@@ -4515,7 +4516,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT;
         spellInfo->Effects[EFFECT_2].Effect = spellInfo->Effects[EFFECT_0].Effect;
         spellInfo->Effects[EFFECT_0].Effect = 0;
-        spellInfo->Effects[EFFECT_0].DieSides = spellInfo->Effects[EFFECT_0].DieSides;
+        spellInfo->Effects[EFFECT_2].DieSides = spellInfo->Effects[EFFECT_0].DieSides;
         spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_0].TargetB;
         spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
         spellInfo->Effects[EFFECT_2].BasePoints = spellInfo->Effects[EFFECT_0].BasePoints;
@@ -4736,7 +4737,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Jormungar Bite
-    ApplySpellFix({ 50990 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 56103 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5275,7 +5276,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 57143 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
-        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(0);
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo();
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
@@ -5349,6 +5350,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // XT-002 DECONSTRUCTOR
+    // Boom (XT-002)
     ApplySpellFix({ 62834 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
@@ -6240,7 +6242,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Saber Lash (Lord Marrowgar)
     ApplySpellFix({ 69055, 70814 }, [](SpellInfo * spellInfo)
     {
-        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(8); // 5yd
     });
 
     // Impaled (Lord Marrowgar)
@@ -6637,6 +6639,12 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 73529 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);   // 10yd
+    });
+
+    // Shadow Trap (searcher)
+    ApplySpellFix({ 74282 }, [](SpellInfo * spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS);   // 3yd
     });
 
     // Raging Spirit Visual

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4102,7 +4102,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Horn of Winter, stacking issues
     ApplySpellFix({ 57330, 57623 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_1].TargetA = 0;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo();
     });
 
     // Scourge Strike trigger
@@ -4376,14 +4376,14 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Mirror Image - Summon Spells
     ApplySpellFix({ 58831, 58833, 58834, 65047 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_CASTER;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
     });
 
     // Initialize Images (Mirror Image)
     ApplySpellFix({ 58836 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Arcane Blast, can't be dispelled
@@ -4476,7 +4476,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Improved Spell Reflection
     ApplySpellFix({ 59725 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_CASTER_AREA_PARTY;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER_AREA_PARTY);
     });
     
     /////////////////////////////////
@@ -4526,7 +4526,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ALLY;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ALLY);
     });
 
     /////////////////////////////////
@@ -4611,7 +4611,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 34074 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
-        spellInfo->Effects[EFFECT_2].TargetA = 1;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(1);
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_DUMMY;
     });
 
@@ -4717,7 +4717,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Jormungar Bite
     ApplySpellFix({ 50990 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_TARGET_ENEMY;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
     
@@ -4728,7 +4728,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Throw Proximity Bomb
     ApplySpellFix({ 34095 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_TARGET_ENEMY;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
@@ -4859,7 +4859,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_SCHOOL_ABSORB;
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_2].MiscValue = SPELL_SCHOOL_MASK_MAGIC;
     });
 
@@ -5198,7 +5198,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Haste (Nexus Lord, increase run speed of the disk)
     ApplySpellFix({ 57060 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_VEHICLE;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_VEHICLE);
     });
 
     // Arcane Overload
@@ -5227,10 +5227,10 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Destroy Platform Event
     ApplySpellFix({ 59099 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_1].TargetA = 22;
-        spellInfo->Effects[EFFECT_1].TargetB = 15;
-        spellInfo->Effects[EFFECT_2].TargetA = 22;
-        spellInfo->Effects[EFFECT_2].TargetB = 15;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(22);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(15);
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(22);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(15);
     });
 
     // Surge of Power (Phase 3) | Normal and Heroic
@@ -5251,8 +5251,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(0);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_SRC_CASTER;
-        spellInfo->Effects[EFFECT_1].TargetB = TARGET_UNIT_SRC_AREA_ALLY;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
         spellInfo->Effects[EFFECT_1].PointsPerComboPoint = 2500;
         spellInfo->Effects[EFFECT_1].BasePoints = 2499;
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(1);
@@ -5519,7 +5519,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(328); // 250ms
-        spellInfo->Effects[EFFECT_1].TargetA = 1;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(1);
         
         if (spellInfo->Effects[EFFECT_1].Effect)
         {
@@ -5724,10 +5724,10 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_TAUNT;
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_NEARBY_ENTRY;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_MOD_STUN;
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35); // 4 secs
     });
 
@@ -6027,8 +6027,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_1].Effect = 0;
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_SRC_CASTER;
-        spellInfo->Effects[EFFECT_2].TargetB = TARGET_UNIT_SRC_AREA_ENTRY;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
         spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(30); // 500yd
     });
 
@@ -6065,10 +6065,10 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_TARGET_ANY;
-        spellInfo->Effects[EFFECT_1].TargetB = 0;
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
-        spellInfo->Effects[EFFECT_2].TargetB = 0;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
@@ -6139,7 +6139,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Frostsworn General - Throw Shield
     ApplySpellFix({ 69222, 73076 }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ENEMY;
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
     });
 
     // Halls of Reflection Clone
@@ -6228,7 +6228,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 69138 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_DEST_DEST;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 secs instead of 12, need him for longer, but will stop his actions after 12 secs
     });
 
@@ -6732,7 +6732,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({ 76221 }, [](SpellInfo* spellInfo)
     {
         spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_TURNING | AURA_INTERRUPT_FLAG_MOVE);
-        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_NEARBY_ENTRY;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
     });
 
     // Intimidating Roar
@@ -6816,7 +6816,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_DEST_AREA_ENTRY;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENTRY);
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
     });
 
@@ -6846,7 +6846,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         69489  // Bonbon Blitz (24636)
     }, [](SpellInfo* spellInfo)
     {
-        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Control (9595)
@@ -7027,6 +7027,340 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 52391 - 1;
     });
+
+    // The Sum is Greater than the Parts (13043) - Chained Grip
+    ApplySpellFix({ 60540 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValue = 300;
+    });
+
+    // Not a Bug (13342)
+    ApplySpellFix({ 60531 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
+    });
+
+    // Frankly,  It Makes No Sense... (10672)
+    ApplySpellFix({ 37851 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Honor Challenge (12939)
+    ApplySpellFix({ 21855 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Convocation at Zol'Heb (12730)
+    ApplySpellFix({ 52956 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENTRY);
+    });
+
+    // Mangletooth Quests (http://www.wowhead.com/npc=3430)
+    ApplySpellFix({ 7764, 10767, 16610, 16612, 16618, 17013 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_SKIP_CHECKCAST_LOS_CHECK;
+    });
+
+    // Crushing the Crown
+    ApplySpellFix({ 71024 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
+    });
+
+    // Battle for the Undercity
+    // Cyclone fall
+    ApplySpellFix({ 59892 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
+        spellInfo->AttributesEx &= ~SPELL_ATTR0_CANT_CANCEL;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
+    });
+
+    // ///////////////////////////////////////////
+    // ////////////////ITEMS//////////////////////
+    // ///////////////////////////////////////////
+
+    // Enchant Lightweave Embroidery
+    ApplySpellFix({ 55637 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].MiscValue = 126;
+    });
+
+    // Magic Broom
+    ApplySpellFix({ 47977 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Titanium Seal of Dalaran, Toss your luck
+    ApplySpellFix({ 60476 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+    });
+
+    // Mind Amplification Dish, change charm aura
+    ApplySpellFix({ 26740 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
+    });
+
+    // Persistent Shield (fixes idiocity)
+    ApplySpellFix({ 26467 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 26470;
+    });
+
+    // Deadly Swiftness
+    ApplySpellFix({ 31255 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 22588;
+    });
+
+    // Black Magic enchant
+    ApplySpellFix({ 59630 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
+    });
+
+    // Precious's Ribbon
+    ApplySpellFix({ 72968 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
+    });
+
+    ApplySpellFix({ 
+        71646, // Item - Bauble of True Blood 10m
+        71607, // Item - Bauble of True Blood 25m
+        71610, // Item - Althor's Abacus trigger 10m
+        71641  // Item - Althor's Abacus trigger 25m
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+        spellInfo->SpellLevel = 0;
+    });
+
+    // Drain Life - Bryntroll Normal / Heroic
+    ApplySpellFix({ 71838, 71839 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    // Alchemist's Stone
+    ApplySpellFix({ 17619 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
+    });
+
+    // Gnomish Death Ray
+    ApplySpellFix({ 13278, 13280 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+    });
+
+    // Stormchops
+    ApplySpellFix({ 43730 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(1);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Savory Deviate Delight (transformations), allow to mount while transformed
+    ApplySpellFix({ 8219, 8220, 8221, 8222 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+    });
+
+    // Clamlette Magnifique
+    ApplySpellFix({ 72623 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = spellInfo->Effects[EFFECT_1].BasePoints;
+    });
+
+    // Compact Harvest Reaper
+    ApplySpellFix({ 4078 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6); // 10 minutes
+    });
+
+    // Dragon Kite, Tuskarr Kite - Kite String
+    ApplySpellFix({ 45192 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
+    });
+
+    // Frigid Frostling, Infrigidate
+    ApplySpellFix({ 74960 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(9); // 20yd
+    });
+
+    // ///////////////////////////////////////////
+    // ////////////////EVENTS/////////////////////
+    // ///////////////////////////////////////////
+
+    //////////////////////////////////////////
+    ////////// BREWFEST
+    //////////////////////////////////////////
+
+    // Apple Trap
+    ApplySpellFix({ 43450 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+    });
+
+    // Dark Iron Attack - spawn mole machine
+    ApplySpellFix({ 43563 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = 0; // summon GO's manually
+    });
+
+    // Throw Mug visual
+    ApplySpellFix({ 42300 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    // Dark Iron knockback Aura
+    ApplySpellFix({ 42299 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY;
+        spellInfo->Effects[EFFECT_0].MiscValue = 100;
+        spellInfo->Effects[EFFECT_0].BasePoints = 79;
+    });
+
+    // Chug and Chuck!
+    ApplySpellFix({ 42436 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+        spellInfo->MaxAffectedTargets = 0;
+        spellInfo->ExcludeCasterAuraSpell = 42299;
+    });
+
+    // Catch the Wild Wolpertinger!
+    ApplySpellFix({ 41621 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+    });
+
+    // Brewfest quests
+    ApplySpellFix({ 47134, 51798 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+    });
+
+    // The Heart of The Storms (12998)
+    ApplySpellFix({ 43528 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
+    });
+
+    //////////////////////////////////////////
+    ////////// Hallow's End
+    //////////////////////////////////////////
+
+    // Water splash
+    ApplySpellFix({ 42348 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+    });
+
+    // Summon Lantersn
+    ApplySpellFix({ 44255, 44231 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Throw Head Back
+    ApplySpellFix({ 42401 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    //////////////////////////////////////////
+    ////////// Pilgrim's Bounty
+    //////////////////////////////////////////
+    
+    // Various food
+    ApplySpellFix({ 65418 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TriggerSpell = 65410;
+    });
+
+    ApplySpellFix({ 65422 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TriggerSpell = 65414;
+    });
+
+    ApplySpellFix({ 65419 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TriggerSpell = 65416;
+    });
+
+    ApplySpellFix({ 65420 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TriggerSpell = 65412;
+    });
+
+    ApplySpellFix({ 65421 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TriggerSpell = 65415;
+    });
+
+    //////////////////////////////////////////
+    ////////// Midsummer
+    //////////////////////////////////////////
+    
+    // Stamp Out Bonfire
+    ApplySpellFix({ 45437 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Light Bonfire (DND)
+    ApplySpellFix({ 29831 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    //////////////////////////////////////////
+    ////////// Misc Events
+    //////////////////////////////////////////
+    
+    // Infernal
+    ApplySpellFix({ 33240 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    // Check for SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER
+    ApplySpellFix({ 
+        47476, // Deathknight - Strangulate
+        15487, // Priest - Silence
+        5211,  // Druid - Bash  - R1
+        6798,  // Druid - Bash  - R2
+        8983   // Druid - Bash  - R3 
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx7 |= SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER;
+    });
     
     for (auto spellInfo : mSpellInfoMap)
     {
@@ -7050,277 +7384,15 @@ void SpellMgr::LoadSpellInfoCorrections()
         }
 
         // Xinef: Fix range for trajectories and triggered spells
-        {
-            auto _spellEntry = (SpellEntry*)sSpellStore.LookupEntry(spellInfo->Id);
-            for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-                if (_spellEntry->rangeIndex == 1 && (_spellEntry->EffectImplicitTargetA[j] == TARGET_DEST_TRAJ || _spellEntry->EffectImplicitTargetB[j] == TARGET_DEST_TRAJ))
-                    if (SpellEntry* spellInfo2 = (SpellEntry*)sSpellStore.LookupEntry(_spellEntry->EffectTriggerSpell[j]))
-                        spellInfo2->rangeIndex = 187; // 300yd
-        }
+        auto _spellEntry = (SpellEntry*)sSpellStore.LookupEntry(spellInfo->Id);
+        for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
+            if (_spellEntry->rangeIndex == 1 && (_spellEntry->EffectImplicitTargetA[j] == TARGET_DEST_TRAJ || _spellEntry->EffectImplicitTargetB[j] == TARGET_DEST_TRAJ))
+                if (SpellEntry* spellInfo2 = (SpellEntry*)sSpellStore.LookupEntry(_spellEntry->EffectTriggerSpell[j]))
+                    spellInfo2->rangeIndex = 187; // 300yd
 
-        if (spellInfo->ActiveIconID == 2158)  // flight
+        if (spellInfo->ActiveIconID == 2158) // flight
             spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
-
-        switch (spellInfo->Id)
-        {
-            // Dark Horizon (12664), Reunited (12663)
-            case 52190:
-                spellInfo->Effects[EFFECT_0].BasePoints = 52391 - 1;
-                break;
-            // The Sum is Greater than the Parts (13043) - Chained Grip
-            case 60540:
-                spellInfo->Effects[EFFECT_0].MiscValue = 300;
-                break;
-            // Not a Bug (13342)
-            case 60531:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
-                break;
-            // Frankly,  It Makes No Sense... (10672)
-            case 37851:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Honor Challenge (12939)
-            case 21855:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Convocation at Zol'Heb (12730)
-            case 52956:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENTRY);
-                break;
-            // Mangletooth Quests (http://www.wowhead.com/npc=3430)
-            case 7764:
-            case 10767:
-            case 16610:
-            case 16612:
-            case 16618:
-            case 17013:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_SKIP_CHECKCAST_LOS_CHECK;
-                break;
-            //Crushing the Crown
-            case 71024:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
-                break;
-            // Battle for the Undercity
-            case 59892: // Cyclone fall
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
-                spellInfo->AttributesEx &= ~SPELL_ATTR0_CANT_CANCEL;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
-                break;
-
-            // ///////////////////////////////////////////
-            // ////////////////ITEMS//////////////////////
-            // ///////////////////////////////////////////
-            // enchant Lightweave Embroidery
-            case 55637:
-                spellInfo->Effects[EFFECT_1].MiscValue = 126;
-                break;
-            // Magic Broom
-            case 47977:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            // Titanium Seal of Dalaran, Toss your luck
-            case 60476:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                break;
-            // Mind Amplification Dish, change charm aura
-            case 26740:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
-                break;
-            // Persistent Shield (fixes idiocity)
-            case 26467:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 26470;
-                break;
-            // Deadly Swiftness
-            case 31255:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 22588;
-                break;
-            // Black Magic enchant
-            case 59630:
-                spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
-                break;
-            // Precious's Ribbon
-            case 72968:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
-                break;
-            // Item - Bauble of True Blood 10m
-            // Item - Bauble of True Blood 25m
-            case 71646:
-            case 71607:
-            // Item - Althor's Abacus trigger 10m
-            // Item - Althor's Abacus trigger 25m
-            case 71610:
-            case 71641:
-                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
-                spellInfo->SpellLevel = 0;
-                break;
-            // Drain Life - Bryntroll Normal / Heroic
-            case 71838:
-            case 71839:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-            // Alchemist's Stone
-            case 17619:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
-                break;
-            // Gnomish Death Ray
-            case 13278:
-            case 13280:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                break;
-            // Stormchops
-            case 43730:
-                spellInfo->Effects[EFFECT_1].TargetA = 1;
-                spellInfo->Effects[EFFECT_1].TargetB = 0;
-                break;
-            // Savory Deviate Delight (transformations), allow to mount while transformed
-            case 8219:
-            case 8220:
-            case 8221:
-            case 8222:
-                spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                break;
-            // Clamlette Magnifique
-            case 72623: // drink triggered spell
-                spellInfo->Effects[EFFECT_0].BasePoints = spellInfo->Effects[EFFECT_1].BasePoints;
-                break;
-            // Compact Harvest Reaper
-            case 4078:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6); // 10 minutes
-                break;
-            // Dragon Kite, Tuskarr Kite - Kite String
-            case 45192:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
-                break;
-            // Frigid Frostling, Infrigidate
-            case 74960:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(9); // 20yd
-                break;
-
-
-            // ///////////////////////////////////////////
-            // ////////////////EVENTS/////////////////////
-            // ///////////////////////////////////////////
-
-            //////////////////////////////////////////
-            ////////// BREWFEST
-            //////////////////////////////////////////
-            // Apple Trap
-            case 43450:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-                break;
-            // Dark Iron Attack - spawn mole machine
-            case 43563:
-                spellInfo->Effects[EFFECT_2].Effect = 0; // summon GO's manually
-                break;
-            // Throw Mug visual
-            case 42300:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            // Dark Iron knockback Aura
-            case 42299:
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY;
-                spellInfo->Effects[EFFECT_0].MiscValue = 100;
-                spellInfo->Effects[EFFECT_0].BasePoints = 79;
-                break;
-            // Chug and Chuck!
-            case 42436:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                spellInfo->MaxAffectedTargets = 0;
-                spellInfo->ExcludeCasterAuraSpell = 42299;
-                break;
-            // Catch the Wild Wolpertinger!
-            case 41621:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-                break;
-            // Brewfest quests
-            case 47134:
-            case 51798:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                break;
-            // The Heart of The Storms (12998)
-            case 43528:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
-                break;
-
-            //////////////////////////////////////////
-            ////////// Hallow's End
-            //////////////////////////////////////////
-            // Water splash
-            case 42348:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                break;
-            // Summon Lantersn
-            case 44255:
-            case 44231:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Throw Head Back
-            case 42401:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
-                break;
-
-            //////////////////////////////////////////
-            ////////// Pilgrim's Bounty
-            //////////////////////////////////////////
-            // Various food
-            case 65418:
-                spellInfo->Effects[EFFECT_2].TriggerSpell = 65410;
-                break;
-            case 65422:
-                spellInfo->Effects[EFFECT_2].TriggerSpell = 65414;
-                break;
-            case 65419:
-                spellInfo->Effects[EFFECT_2].TriggerSpell = 65416;
-                break;
-            case 65420:
-                spellInfo->Effects[EFFECT_2].TriggerSpell = 65412;
-                break;
-            case 65421:
-                spellInfo->Effects[EFFECT_2].TriggerSpell = 65415;
-                break;
-
-            //////////////////////////////////////////
-            ////////// Midsummer
-            //////////////////////////////////////////
-            // Stamp Out Bonfire
-            case 45437:
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_NEARBY_ENTRY;
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // Light Bonfire (DND)
-            case 29831:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            //////////////////////////////////////////
-            ////////// Misc Events
-            //////////////////////////////////////////
-            // Infernal
-            case 33240:
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_DEST_TARGET_ANY;
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_TARGET_ANY;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ANY;
-                break;
-            // Check for SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER
-            case 47476: // Deathknight - Strangulate
-            case 15487: // Priest - Silence
-            case 5211:  // Druid - Bash  - R1
-            case 6798:  // Druid - Bash  - R2
-            case 8983:  // Druid - Bash  - R3
-                spellInfo->AttributesEx7 |= SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER;
-                break;
-        }
-
+        
         switch (spellInfo->SpellFamilyName)
         {
             case SPELLFAMILY_PALADIN:
@@ -7347,12 +7419,12 @@ void SpellMgr::LoadSpellInfoCorrections()
                 areaEntry->flags |= AREA_FLAG_REST_ZONE_ALLIANCE;
         }
 
-
     // Xinef: fix for something?
     SummonPropertiesEntry* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(121));
     properties->Type = SUMMON_TYPE_TOTEM;
     properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(647)); // 52893
     properties->Type = SUMMON_TYPE_TOTEM;
+    
     if ((properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(628)))) // Hungry Plaguehound
     {
         properties->Category = SUMMON_CATEGORY_PET;
@@ -7362,7 +7434,6 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Correct Pet Size
     CreatureDisplayInfoEntry* displayEntry = const_cast<CreatureDisplayInfoEntry*>(sCreatureDisplayInfoStore.LookupEntry(17028)); // Kurken
     displayEntry->scale = 2.5f;
-
 
     // Oracles and Frenzyheart faction
     FactionEntry* factionEntry = const_cast<FactionEntry*>(sFactionStore.LookupEntry(1104));
@@ -7377,7 +7448,6 @@ void SpellMgr::LoadSpellInfoCorrections()
     factionTemplateEntry = const_cast<FactionTemplateEntry*>(sFactionTemplateStore.LookupEntry(1921)); // The Taunka
     factionTemplateEntry->hostileMask |= 8;
 
-
     // Remove vehicles attr, making accessories selectable
     VehicleSeatEntry* vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(4689)); // Siege Engine, Accessory
     vse->m_flags &= ~VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE;
@@ -7389,7 +7459,6 @@ void SpellMgr::LoadSpellInfoCorrections()
     vse->m_flags &= ~VEHICLE_SEAT_FLAG_CAN_SWITCH;
     vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(3077)); // Salvaged Demolisher Seat, Ulduar - not allow to change seats
     vse->m_flags &= ~VEHICLE_SEAT_FLAG_CAN_SWITCH;
-
 
     // pussywizard: fix z offset for some vehicles:
     vse = const_cast<VehicleSeatEntry*>(sVehicleSeatStore.LookupEntry(6206)); // Marrowgar - Bone Spike
@@ -7420,12 +7489,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     vse->m_attachmentOffsetX += 0.0f;
     vse->m_attachmentOffsetY += 1.6f;
 
-
-
     // Once Bitten, Twice Shy (10 player) - Icecrown Citadel
     AchievementEntry* achievement = const_cast<AchievementEntry*>(sAchievementStore.LookupEntry(4539));
-    achievement->mapID = 631;    // Correct map requirement (currently has Ulduar)
-
+    achievement->mapID = 631;  // Correct map requirement (currently has Ulduar)
 
     // Ring of Valor starting Locations
     GraveyardStruct const* entry = sGraveyard->GetGraveyard(1364);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3465,7 +3465,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         51124, // Killing Machine
         54741, // Firestarter
         57761, // Fireball!
-        39805, // Lightning Overload
+        // 39805, // Lightning Overload
         64823, // Item - Druid T8 Balance 4P Bonus
         34477, // Misdirection
         44401, // Missile Barrage

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4026,7 +4026,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     ApplySpellFix(
     {
-        31221, // Master of Subtlety triggers
+        31666, // Master of Subtlety triggers
         58428  // Overkill
     }, [](SpellInfo * spellInfo)
     {
@@ -4679,13 +4679,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Army of the Dead (trigger npc aura)
-    ApplySpellFix({ 48739 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 49099 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 15000;
     });
 
     // Isle of Conquest - Teleport in, missing range
-    ApplySpellFix({ 48739 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 66551 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 50000yd
     });
@@ -4831,7 +4831,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // The Arcatraz
     // Negaton Field
-    ApplySpellFix({ 38794 /*Normal*/, 33711 /*Heroic*/ }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 36729 /*Normal*/, 38834 /*Heroic*/ }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
@@ -5481,7 +5481,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // ALGALON
     // Cosmic Smash (Algalon the Observer)
-    ApplySpellFix({ 62714, 65209 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 62293 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
     });
@@ -6346,7 +6346,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Gunship Battle, spell Below Zero
-    ApplySpellFix({ 72864 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 69705 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
@@ -7113,7 +7113,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
     });
 
-    // Frankly,  It Makes No Sense... (10672)
+    // Frankly, It Makes No Sense... (10672)
     ApplySpellFix({ 37851 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3327,7 +3327,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         45634  // Neural Needle
     }, [](SpellInfo * spellInfo)
     {
-        spellInfo->MaxAffectedTargets = 1;
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
     });
 
     ApplySpellFix(
@@ -3364,8 +3364,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     // Headless Horseman
     ApplySpellFix(
     {
-        42818, // Headless Horseman - Wisp Flight Port
-        42821  // Headless Horseman - Wisp Flight Missile
+        42818, // Wisp Flight Port
+        42821  // Wisp Flight Missile
     }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100 yards
@@ -3567,7 +3567,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Ebon Plague
-    ApplySpellFix({ 41013 }, [](SpellInfo * spellInfo)
+    ApplySpellFix({ 51735, 51734, 51726 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags[2] = 0x10;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
@@ -3595,11 +3595,8 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // target allys instead of enemies, target A is src_caster, spells with effect like that have ally target
     // this is the only known exception, probably just wrong data
-    ApplySpellFix(
-    {
-        29214, // Wrath of the Plaguebringer
-        54836  // Wrath of the Plaguebringer
-    }, [](SpellInfo * spellInfo)
+    /// Wrath of the Plaguebringer
+    ApplySpellFix({ 29214, 54836 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
         spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3288,103 +3288,110 @@ void SpellMgr::LoadSpellInfoCorrections()
     uint32 oldMSTime = getMSTime();
 
     // Evergrove Druid Transform Crow
-    ApplySpellFix({ 38776 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 38776 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(4); // 120 seconds
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         63026, // Force Cast (HACK: Target shouldn't be changed)
         63137  // Force Cast (HACK: Target shouldn't be changed; summon position should be untied from spell destination)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         53096, // Quetz'lun's Judgment
         70743, // AoD Special
         70614 // AoD Special - Vegard
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Summon Skeletons
-    ApplySpellFix({ 52611, 52612 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52611, 52612 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValueB = 64;
     });
 
     // Crashes client on pressing ESC
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         45257, // Using Steam Tonk Controller
         45440, // Steam Tonk Controller
         60256, // Collect Sample
         45634  // Neural Needle
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         40244, // Simon Game Visual
         40245, // Simon Game Visual
         40246, // Simon Game Visual
         40247, // Simon Game Visual
         42835  // Spout, remove damage effect, only anim is needed
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         63665, // Charge (Argent Tournament emote on riders)
         31298, // Sleep (needs target selection script)
         2895,  // Wrath of Air Totem rank 1 (Aura)
         68933, // Wrath of Air Totem rank 2 (Aura)
         29200, // Purify Helboar Meat
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Howl of Azgalor
-    ApplySpellFix({ 31344 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31344 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS); // 100yards instead of 50000?!
     });
 
     // Headless Horseman
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         42818, // Headless Horseman - Wisp Flight Port
         42821  // Headless Horseman - Wisp Flight Missile
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100 yards
     });
 
     // They Must Burn Bomb Aura (self)
-    ApplySpellFix({ 36350 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 36350 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 36325; // They Must Burn Bomb Drop (DND)
     });
 
     // Mana Shield (rank 2)
-    ApplySpellFix({ 8494 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 8494 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcChance = 0; // because of bug in dbc
     });
 
     // Glyph of Life Tap
-    ApplySpellFix({ 63320 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63320 }, [](SpellInfo * spellInfo)
     {
         // Entries were not updated after spell effect change, we have to do that manually :/
         spellInfo->AttributesEx3 |= SPELL_ATTR3_CAN_PROC_WITH_TRIGGERED;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         31347, // Doom
         41635, // Prayer of Mending
         39365, // Thundering Storm
@@ -3396,56 +3403,59 @@ void SpellMgr::LoadSpellInfoCorrections()
         42611, // Shoot
         61588, // Blazing Harpoon
         36327  // Shoot Arcane Explosion Arrow
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Skartax Purple Beam
-    ApplySpellFix({ 36384 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 36384 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 2;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         37790, // Spread Shot
         54172, // Divine Storm (heal)
         66588, // Flaming Spear
         54171  // Divine Storm
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 3;
     });
 
     // Divine Storm (Damage)
-    ApplySpellFix({ 53385 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53385 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 4;
     });
 
     // Spitfire Totem
-    ApplySpellFix({ 38296 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 38296 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 5;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         40827, // Sinful Beam
         40859, // Sinister Beam
         40860, // Vile Beam
         40861  // Wicked Beam
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 10;
     });
 
     // Unholy Frenzy
-    ApplySpellFix({ 50312 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50312 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 15;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         17941, // Shadow Trance
         22008, // Netherwind Focus
         31834, // Light's Grace
@@ -3460,75 +3470,76 @@ void SpellMgr::LoadSpellInfoCorrections()
         34477, // Misdirection
         44401, // Missile Barrage
         18820  // Insight
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 1;
     });
 
     // Tidal Wave
-    ApplySpellFix({ 53390 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53390 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 2;
     });
 
     // Oscillation Field
-    ApplySpellFix({ 37408 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 37408 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Ascendance (Talisman of Ascendance trinket)
-    ApplySpellFix({ 28200 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 28200 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 6;
     });
 
     // The Eye of Acherus (no spawn in phase 2 in db)
-    ApplySpellFix({ 51852 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51852 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValue |= 1;
     });
 
     // Crafty's Ultra-Advanced Proto-Typical Shortening Blaster
-    ApplySpellFix({ 51912 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51912 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 3000;
     });
 
     // Desecration Arm - 36 instead of 37 - typo? :/
-    ApplySpellFix({ 29809 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29809 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(37);
     });
 
     // Sic'em
-    ApplySpellFix({ 42767 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42767 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
     });
 
     // Master Shapeshifter: missing stance data for forms other than bear - bear version has correct data
     // To prevent aura staying on target after talent unlearned
-    ApplySpellFix({ 48420 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48420 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Stances = 1 << (FORM_CAT - 1);
     });
 
-    ApplySpellFix({ 48421 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48421 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Stances = 1 << (FORM_MOONKIN - 1);
     });
 
-    ApplySpellFix({ 48422 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48422 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Stances = 1 << (FORM_TREE - 1);
     });
 
     // Elemental Oath
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         51466, // Elemental Oath (Rank 1)
         51470  // Elemental Oath (Rank 2)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
@@ -3537,26 +3548,26 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Improved Shadowform (Rank 1)
-    ApplySpellFix({ 47569 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47569 }, [](SpellInfo * spellInfo)
     {
         // with this spell atrribute aura can be stacked several times
         spellInfo->Attributes &= ~SPELL_ATTR0_NOT_SHAPESHIFT;
     });
 
     // Nether Portal - Perseverence
-    ApplySpellFix({ 30421 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 30421 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].BasePoints += 30000;
     });
 
     // Natural shapeshifter
-    ApplySpellFix({ 16834, 16835 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 16834, 16835 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
     });
 
     // Ebon Plague
-    ApplySpellFix({ 41013 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41013 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags[2] = 0x10;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
@@ -3564,78 +3575,83 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Parasitic Shadowfiend Passive
-    ApplySpellFix({ 41013 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41013 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY; // proc debuff, and summon infinite fiends
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         27892, // To Anchor 1
         27928, // To Anchor 1
         27935, // To Anchor 1
         27915, // Anchor to Skulls
         27931, // Anchor to Skulls
         27937  // Anchor to Skulls
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
     });
 
     // target allys instead of enemies, target A is src_caster, spells with effect like that have ally target
     // this is the only known exception, probably just wrong data
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         29214, // Wrath of the Plaguebringer
         54836  // Wrath of the Plaguebringer
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
         spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
     });
 
     // Wind Shear - improper data for EFFECT_1 in 3.3.5 DBC, but is correct in 4.x
-    ApplySpellFix({ 57994 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57994 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_MODIFY_THREAT_PERCENT;
         spellInfo->Effects[EFFECT_1].BasePoints = -6; // -5%
     });
 
     // Improved Devouring Plague
-    ApplySpellFix({ 63675 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63675 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BonusMultiplier = 0;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         8145, // Tremor Totem (instant pulse)
         6474  // Earthbind Totem (instant pulse)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx5 |= SPELL_ATTR5_START_PERIODIC_AT_APPLY;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         53241, // Marked for Death (Rank 1)
         53243, // Marked for Death (Rank 2)
         53244, // Marked for Death (Rank 3)
         53245, // Marked for Death (Rank 4)
         53246  // Marked for Death (Rank 5)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(423937, 276955137, 2049);
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         70728, // Exploit Weakness
         70840  // Devious Minds
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_PET);
     });
 
     // Culling The Herd
-    ApplySpellFix({ 70893 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70893 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
@@ -3645,60 +3661,63 @@ void SpellMgr::LoadSpellInfoCorrections()
     // this is done because another spell also uses the same SpellFamilyFlags as Icy Touch
     // SpellFamilyFlags[0] & 0x00000040 in SPELLFAMILY_DEATHKNIGHT is currently unused (3.3.5a)
     // this needs research on modifier applying rules, does not seem to be in Attributes fields
-    ApplySpellFix({ 54800 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54800 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000040, 0x00000000, 0x00000000);
     });
 
     // Idol of the Flourishing Life
-    ApplySpellFix({ 64949 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64949 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x00000000, 0x02000000, 0x00000000);
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         34231, // Libram of the Lightbringer
         60792, // Libram of Tolerance
         64956  // Libram of the Resolute
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x80000000, 0x00000000, 0x00000000);
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         28851, // Libram of Light
         28853, // Libram of Divinity
         32403  // Blessed Book of Nagrand
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x40000000, 0x00000000, 0x00000000);
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
     });
 
     // Ride Carpet
-    ApplySpellFix({ 45602 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45602 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 0; // force seat 0, vehicle doesn't have the required seat flags for "no seat specified (-1)"
     });
 
-    ApplySpellFix({
+    ApplySpellFix(
+    {
         64745, // Item - Death Knight T8 Tank 4P Bonus
         64936  // Item - Warrior T8 Protection 4P Bonus
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 100; // 100% chance of procc'ing, not -10% (chance calculated in PrepareTriggersExecutedOnHit)
     });
 
     // Easter Lay Noblegarden Egg Aura - Interrupt flags copied from aura which this aura is linked with
-    ApplySpellFix({ 61719 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61719 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE;
     });
 
     // Spell for item The Flag of Ownership (38578)
-    ApplySpellFix({ 51640 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51640 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
@@ -3706,26 +3725,26 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // The Beast Within
-    ApplySpellFix({ 34471 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34471 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_CONFUSED | SPELL_ATTR5_USABLE_WHILE_FEARED | SPELL_ATTR5_USABLE_WHILE_STUNNED;
     });
 
     // Introspection
-    ApplySpellFix({ 40055, 40165, 40166, 40167 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40055, 40165, 40166, 40167 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
     });
 
     // Minor Fortitude
-    ApplySpellFix({ 2378 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 2378 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ManaCost = 0;
         spellInfo->ManaPerSecond = 0;
     });
 
     // Threatening Gaze
-    ApplySpellFix({ 24314 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 24314 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CAST | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_JUMP;
     });
@@ -3737,9 +3756,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// PALADIN
     /////////////////////////////////
-    
+
     // Heart of the Crusader
-    ApplySpellFix({ 20335, 20336, 20337 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20335, 20336, 20337 }, [](SpellInfo * spellInfo)
     {
         if (spellInfo->Id == 20335)
             spellInfo->Effects[EFFECT_0].TriggerSpell = 21183;
@@ -3747,40 +3766,40 @@ void SpellMgr::LoadSpellInfoCorrections()
             spellInfo->Effects[EFFECT_0].TriggerSpell = 54498;
         else
             spellInfo->Effects[EFFECT_0].TriggerSpell = 54499;
-        
+
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
     });
 
     // Bleh, need to change FamilyFlags :/ (have the same as original aura - bad!)
-    ApplySpellFix({ 63510 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63510 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags[0] = 0;
         spellInfo->SpellFamilyFlags[2] = 0x4000000;
     });
 
-    ApplySpellFix({ 63514 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63514 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags[0] = 0;
         spellInfo->SpellFamilyFlags[2] = 0x2000000;
     });
 
-    ApplySpellFix({ 63531 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63531 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags[0] = 0;
         spellInfo->SpellFamilyFlags[2] = 0x8000000;
     });
 
     // And affecting spells
-    
+
     // Improved Devotion Aura
-    ApplySpellFix({ 20138, 20139, 20140 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20138, 20139, 20140 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
         spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x2000000;
     });
 
     // Improved concentration aura
-    ApplySpellFix({ 20254, 20255, 20256 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20254, 20255, 20256 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].SpellClassMask[0] = 0;
         spellInfo->Effects[EFFECT_1].SpellClassMask[2] = 0x4000000;
@@ -3789,21 +3808,21 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Swift Retribution
-    ApplySpellFix({ 53379, 53484, 53648 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53379, 53484, 53648 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
         spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
     });
 
     // Sanctified Retribution
-    ApplySpellFix({ 31869 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31869 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask[0] = 0;
         spellInfo->Effects[EFFECT_0].SpellClassMask[2] = 0x8000000;
     });
 
     // Seal of Light trigger
-    ApplySpellFix({ 20167 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20167 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellLevel = 0;
         spellInfo->BaseLevel = 0;
@@ -3811,32 +3830,32 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Light's Beacon, Beacon of Light
-    ApplySpellFix({ 53651 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53651 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Hand of Reckoning
-    ApplySpellFix({ 62124 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62124 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
     });
 
     // Redemption
-    ApplySpellFix({ 7328, 10322, 10324, 20772, 20773, 48949, 48950 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 7328, 10322, 10324, 20772, 20773, 48949, 48950 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyName = SPELLFAMILY_PALADIN;
     });
 
     // hack for seal of light and few spells, judgement consists of few single casts and each of them can proc
     // some spell, base one has disabled proc flag but those dont have this flag
-    ApplySpellFix({ 20184, 20185, 20186, 68055 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20184, 20185, 20186, 68055 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
     });
 
     // Blessing of sanctuary stats
-    ApplySpellFix({ 67480 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67480 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValue = -1;
         spellInfo->SpellFamilyName = SPELLFAMILY_UNK1; // allows stacking
@@ -3844,16 +3863,17 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Seal of Command trigger
-    ApplySpellFix({ 20424 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 20424 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         54968, // Glyph of Holy Light, Damage Class should be magic
         53652, // Beacon of Light heal, Damage Class should be magic
         53654  // Beacon of Light heal, Damage Class should be magic
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
@@ -3862,9 +3882,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// HUNTER
     /////////////////////////////////
-    
+
     // Furious Howl
-    ApplySpellFix({ 64491, 64492, 64493, 64494, 64495 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64491, 64492, 64493, 64494, 64495 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
@@ -3873,7 +3893,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Call of the Wild
-    ApplySpellFix({ 53434 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53434 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_MASTER);
@@ -3882,7 +3902,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Wild Hunt
-    ApplySpellFix({ 62758, 62762 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62758, 62762 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
@@ -3891,14 +3911,14 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Intervene
-    ApplySpellFix({ 3411 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 3411 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Roar of Sacrifice
-    ApplySpellFix({ 3411 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 3411 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_SPLIT_DAMAGE_PCT;
@@ -3909,51 +3929,51 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Silencing Shot
-    ApplySpellFix({ 34490, 41084, 42671 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34490, 41084, 42671 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 0.0f;
     });
 
     // Monstrous Bite
-    ApplySpellFix({ 54680, 55495, 55496, 55497, 55498, 55499 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54680, 55495, 55496, 55497, 55498, 55499 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Hunter's Mark
-    ApplySpellFix({ 1130, 14323, 14324, 14325, 53338 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 1130, 14323, 14324, 14325, 53338 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // Cobra Strikes
-    ApplySpellFix({ 53257 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53257 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 2;
         spellInfo->StackAmount = 0;
     });
 
     // Kill Command
-    ApplySpellFix({ 34027 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34027 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 0;
     });
 
     // Kindred Spirits, damage aura
-    ApplySpellFix({ 57458 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57458 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 |= SPELL_ATTR4_UNK21;
     });
 
     // Chimera Shot - Serpent trigger
-    ApplySpellFix({ 53353 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53353 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
     // Entrapment trigger
-    ApplySpellFix({ 19185, 64803, 64804 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 19185, 64803, 64804 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
@@ -3961,19 +3981,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Improved Stings (Rank 2)
-    ApplySpellFix({ 19465 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 19465 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Explosive Shot (trigger)
-    ApplySpellFix({ 53352 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 53352 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // Heart of the Phoenix (triggered)
-    ApplySpellFix({ 54114 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54114 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_DISMISS_PET;
         spellInfo->RecoveryTime = 8 * 60 * IN_MILLISECONDS; // prev 600000
@@ -3984,45 +4004,46 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
 
     // Master of Subtlety
-    ApplySpellFix({ 31221, 31222, 31223 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31221, 31222, 31223 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyName = SPELLFAMILY_ROGUE;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         31221, // Master of Subtlety triggers
         58428  // Overkill
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SCRIPT_EFFECT;
     });
 
     // Honor Among Thieves
-    ApplySpellFix({ 51698, 51700, 51701 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51698, 51700, 51701 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 51699;
     });
 
     // Slice and Dice | Distract
-    ApplySpellFix({ 5171, 6774, 1725 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 5171, 6774, 1725 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Envenom
-    ApplySpellFix({ 32645, 32684, 57992, 57993 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 32645, 32684, 57992, 57993 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Dispel = DISPEL_NONE;
     });
 
     // Killing Spree (teleport)
-    ApplySpellFix({ 57840 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57840 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100 yards
     });
 
     // Killing Spree
-    ApplySpellFix({ 51690 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51690 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_NOT_BREAK_STEALTH;
     });
@@ -4032,7 +4053,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
 
     // Blood Tap visual cd reset
-    ApplySpellFix({ 47804 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47804 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = 0;
         spellInfo->Effects[EFFECT_1].Effect = 0;
@@ -4040,13 +4061,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Chains of Ice
-    ApplySpellFix({ 45524 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45524 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
     // Impurity
-    ApplySpellFix({ 49220, 49633, 49635, 49636, 49638 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49220, 49633, 49635, 49636, 49638 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
@@ -4055,102 +4076,102 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Deadly Aggression (Deadly Gladiator's Death Knight Relic, item: 42620)
-    ApplySpellFix({ 60549 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 60549 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Magic Suppression
-    ApplySpellFix({ 49224, 49610, 49611 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49224, 49610, 49611 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 0;
     });
 
     // Wandering Plague
-    ApplySpellFix({ 50526 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50526 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
         spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Dancing Rune Weapon
-    ApplySpellFix({ 49028 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49028 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = 0;
         spellInfo->ProcFlags |= PROC_FLAG_DONE_MELEE_AUTO_ATTACK;
     });
 
     // Death and Decay
-    ApplySpellFix({ 52212 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52212 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
         spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
     });
 
     // T9 blood plague crit bonus
-    ApplySpellFix({ 67118 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67118 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
-    
+
     // Pestilence
-    ApplySpellFix({ 50842 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50842 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Horn of Winter, stacking issues
-    ApplySpellFix({ 57330, 57623 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57330, 57623 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo();
     });
 
     // Scourge Strike trigger
     // Blood-caked Blade - Blood-caked Strike trigger
-    ApplySpellFix({ 70890, 50463 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70890, 50463 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_CANT_TRIGGER_PROC;
     });
 
     // Blood Gorged - ARP affect Death Strike and Rune Strike
-    ApplySpellFix({ 61274, 61275, 61276, 61277, 61278 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61274, 61275, 61276, 61277, 61278 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask = flag96(0x1400011, 0x20000000, 0x0);
     });
 
     // Death Grip, remove main grip mechanic, leave only effect one
     // Death Grip, should fix taunt on bosses and not break the pull protection at the same time (no aura provides immunity to grip mechanic)
-    ApplySpellFix({ 49576, 49560 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49576, 49560 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Mechanic = 0;
     });
 
     // Death Grip Jump Dest
-    ApplySpellFix({ 57604 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57604 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // Death Pact
-    ApplySpellFix({ 48743 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48743 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_CANT_TARGET_SELF;
     });
 
     // Raise Ally (trigger)
-    ApplySpellFix({ 46619 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 46619 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes &= ~SPELL_ATTR0_CANT_CANCEL;
     });
 
     // Frost Strike
-    ApplySpellFix({ 49143, 51416, 51417, 51418, 51419, 55268 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49143, 51416, 51417, 51418, 51419, 55268 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_BLOCKABLE_SPELL;
     });
 
     // Death Knight T10 Tank 2p Bonus
-    ApplySpellFix({ 70650 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70650 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
     });
@@ -4160,7 +4181,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
 
     // Lightning overload
-    ApplySpellFix({ 45297, 45284 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45297, 45284 }, [](SpellInfo * spellInfo)
     {
         spellInfo->CategoryRecoveryTime = 0;
         spellInfo->RecoveryTime = 0;
@@ -4168,20 +4189,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Improved Earth Shield
-    ApplySpellFix({ 51560, 51561 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51560, 51561 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_DAMAGE;
     });
 
     // Tidal Force
-    ApplySpellFix({ 55166, 55198 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55166, 55198 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
         spellInfo->ProcCharges = 0;
     });
 
     // Healing Stream Totem
-    ApplySpellFix({ 52042 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52042 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellLevel = 0;
         spellInfo->BaseLevel = 0;
@@ -4189,7 +4210,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Earth Shield
-    ApplySpellFix({ 379 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 379 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellLevel = 0;
         spellInfo->BaseLevel = 0;
@@ -4197,33 +4218,33 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Stormstrike
-    ApplySpellFix({ 17364 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 17364 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Strength of Earth totem effect
-    ApplySpellFix({ 8076, 8162, 8163, 10441, 25362, 25527, 57621, 58646 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 8076, 8162, 8163, 10441, 25362, 25527, 57621, 58646 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
         spellInfo->Effects[EFFECT_2].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
     });
 
     // Flametongue Totem effect
-    ApplySpellFix({ 52109, 52110, 52111, 52112, 52113, 58651, 58654, 58655 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52109, 52110, 52111, 52112, 52113, 58651, 58654, 58655 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TargetB = spellInfo->Effects[EFFECT_1].TargetB;
         spellInfo->Effects[EFFECT_2].TargetA = spellInfo->Effects[EFFECT_1].TargetA;
     });
 
     // Sentry Totem
-    ApplySpellFix({ 6495 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 6495 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
     });
 
     // Bind Sight (PT)
-    ApplySpellFix({ 6277 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 6277 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
         spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
@@ -4231,20 +4252,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Ancestral Awakening Heal
-    ApplySpellFix({ 52752 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52752 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
     // Heroism
-    ApplySpellFix({ 32182 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 32182 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 57723; // Exhaustion
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // Bloodlust
-    ApplySpellFix({ 2825 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 2825 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 57724; // Sated
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
@@ -4253,33 +4274,33 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// WARLOCK
     /////////////////////////////////
-    
+
     // Improved Succubus
-    ApplySpellFix({ 18754, 18755, 18756 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 18754, 18755, 18756 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Unstable Affliction
-    ApplySpellFix({ 31117 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31117 }, [](SpellInfo * spellInfo)
     {
         spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
     });
 
     // Shadowflame - trigger
-    ApplySpellFix({ 47960 /*r1*/, 61291 /*r2*/ }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47960 /*r1*/, 61291 /*r2*/ }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
     });
 
     // Curse of Doom - summoned doomguard duration fix
-    ApplySpellFix({ 18662 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 18662 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6);
     });
 
     // Glyph of Voidwalker
-    ApplySpellFix({ 56247 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56247 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
         spellInfo->Effects[EFFECT_0].MiscValue = SPELLMOD_EFFECT1;
@@ -4287,19 +4308,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Everlasting Affliction
-    ApplySpellFix({ 47201, 47202, 47203, 47204, 47205  }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47201, 47202, 47203, 47204, 47205  }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 2; // add corruption to affected spells
     });
 
     // Death's Embrace
-    ApplySpellFix({ 47198, 47199, 47200 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47198, 47199, 47200 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].SpellClassMask[0] |= 0x4000; // include Drain Soul
     });
 
     // Improved Demonic Tactics
-    ApplySpellFix({ 54347, 54348, 54349 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54347, 54348, 54349 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_0].Effect;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = spellInfo->Effects[EFFECT_0].ApplyAuraName;
@@ -4309,13 +4330,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Rain of Fire (Doomguard)
-    ApplySpellFix({ 42227 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42227 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 0.0f;
     });
 
     // Ritual Enslavement
-    ApplySpellFix({ 22987 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 22987 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
     });
@@ -4323,83 +4344,83 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// MAGE
     /////////////////////////////////
-    
+
     // Combustion, make this passive
-    ApplySpellFix({ 11129 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 11129 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Dispel = DISPEL_NONE;
     });
 
     // Magic Absorption (nigga stole my code)
-    ApplySpellFix({ 29441, 29444 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29441, 29444 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellLevel = 0;
     });
 
     // Living Bomb
-    ApplySpellFix({ 44461, 55361, 55362 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 44461, 55361, 55362 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |=  SPELL_ATTR3_NO_INITIAL_AGGRO;
         spellInfo->AttributesEx4 |= SPELL_ATTR4_DAMAGE_DOESNT_BREAK_AURAS;
     });
 
     // Evocation
-    ApplySpellFix({ 12051 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 12051 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
     });
 
     // MI Fireblast, WE Frostbolt, MI Frostbolt
-    ApplySpellFix({ 59637, 31707, 72898 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59637, 31707, 72898 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
     });
 
     // Blazing Speed
-    ApplySpellFix({ 31641, 31642 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31641, 31642 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 31643;
     });
 
     // Summon Water Elemental (permanent), treat it as pet
-    ApplySpellFix({ 70908 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70908 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_SUMMON_PET;
     });
 
     // Burnout, trigger
-    ApplySpellFix({ 44450 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 44450 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_POWER_BURN;
     });
 
     // Mirror Image - Summon Spells
-    ApplySpellFix({ 58831, 58833, 58834, 65047 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 58831, 58833, 58834, 65047 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(0);
     });
 
     // Initialize Images (Mirror Image)
-    ApplySpellFix({ 58836 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 58836 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Arcane Blast, can't be dispelled
-    ApplySpellFix({ 36032 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 36032 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
     });
 
     // Chilled (frost armor, ice armor proc)
-    ApplySpellFix({ 6136, 7321 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 6136, 7321 }, [](SpellInfo * spellInfo)
     {
         spellInfo->PreventionType = SPELL_PREVENTION_TYPE_NONE;
     });
 
     // Mirror Image Frostbolt
-    ApplySpellFix({ 59638 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59638 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->SpellFamilyName = SPELLFAMILY_MAGE;
@@ -4407,7 +4428,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Fingers of Frost
-    ApplySpellFix({ 44544 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 44544 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Dispel = DISPEL_NONE;
         spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
@@ -4415,7 +4436,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Fingers of Frost visual buff
-    ApplySpellFix({ 74396 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74396 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcCharges = 2;
         spellInfo->StackAmount = 0;
@@ -4424,74 +4445,75 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// WARRIOR
     /////////////////////////////////
-    
+
     // Glyph of blocking
-    ApplySpellFix({ 58375 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 58375 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 58374;
     });
 
     // Sweeping Strikes stance change
-    ApplySpellFix({ 12328 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 12328 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
     });
 
     // Damage Shield
-    ApplySpellFix({ 59653 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59653 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->SpellLevel = 0;
     });
 
-     // Strange shared cooldown
-    ApplySpellFix({ 
+    // Strange shared cooldown
+    ApplySpellFix(
+    {
         20230,  // Retaliation
         871,    // Shield Wall
         1719    // Recklessness
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx6 |= SPELL_ATTR6_IGNORE_CATEGORY_COOLDOWN_MODS;
     });
 
     // Vigilance, fixes bug with empowered renew, single target aura
-    ApplySpellFix({ 50720 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50720 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyName = SPELLFAMILY_WARRIOR;
     });
 
     // Sunder Armor - trigger, remove spellfamilyflags because of glyph of sunder armor
-    ApplySpellFix({ 58567 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 58567 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyFlags = flag96(0x0, 0x0, 0x0);
     });
 
     // Sunder Armor - Old Ranks
-    ApplySpellFix({ 7405, 8380, 11596, 11597, 25225, 47467 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 7405, 8380, 11596, 11597, 25225, 47467 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 11971;
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE;
     });
-    
+
     // Improved Spell Reflection
-    ApplySpellFix({ 59725 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59725 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER_AREA_PARTY);
     });
-    
+
     /////////////////////////////////
     ///// PRIEST
     /////////////////////////////////
 
     // Shadow Weaving
-    ApplySpellFix({ 15257, 15331, 15332 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 15257, 15331, 15332 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
     });
-    
+
     // Hymn of Hope - rewrite part of aura system or swap effects...
-    ApplySpellFix({ 64904 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64904 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_INCREASE_ENERGY_PERCENT;
         spellInfo->Effects[EFFECT_2].Effect = spellInfo->Effects[EFFECT_0].Effect;
@@ -4503,26 +4525,27 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Divine Hymn
-    ApplySpellFix({ 64844 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64844 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->SpellLevel = 0;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         // Spiritual Healing affects prayer of mending
-        14898, 15349, 15354, 15355, 15356,             
+        14898, 15349, 15354, 15355, 15356,
         // Divine Providence affects prayer of mending
         47562, 47564, 47565, 47566, 47567,
         // Twin Disciplines affects prayer of mending
         47586, 47587, 47588, 52802, 52803
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].SpellClassMask[1] |= 0x20; // prayer of mending
     });
 
     // Power Infusion, hack to fix stacking with arcane power
-    ApplySpellFix({ 10060 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 10060 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
@@ -4532,47 +4555,47 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
     ///// DRUID
     /////////////////////////////////
-    
+
     // Lifebloom final bloom
-    ApplySpellFix({ 33778 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 33778 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->SpellLevel = 0;
         spellInfo->SpellFamilyFlags = flag96(0, 0x10, 0);
     });
-    
+
     // Clearcasting
-    ApplySpellFix({ 16870 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 16870 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(31); // 8 secs
     });
 
     // Owlkin Frenzy
-    ApplySpellFix({ 48391 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48391 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NOT_SHAPESHIFT;
     });
 
     // Item T10 Restoration 4P Bonus
-    ApplySpellFix({ 70691 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70691 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
     // Faerie Fire, Faerie Fire (Feral)
-    ApplySpellFix({ 770, 16857 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 770, 16857 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE;
     });
 
     // Feral Charge - Cat
-    ApplySpellFix({ 49376, 61138, 61132, 50259 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49376, 61138, 61132, 50259 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Glyph of Barkskin
-    ApplySpellFix({ 63058 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63058 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE;
     });
@@ -4582,19 +4605,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     /////////////////////////////////
 
     // Resurrection Sickness
-    ApplySpellFix({ 15007 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 15007 }, [](SpellInfo * spellInfo)
     {
         spellInfo->SpellFamilyName = SPELLFAMILY_GENERIC;
     });
 
     // Luck of the Draw
-    ApplySpellFix({ 72221 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72221 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
     });
 
     // Bind
-    ApplySpellFix({ 3286 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 3286 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets = 0; // neutral innkeepers not friendly?
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
@@ -4602,13 +4625,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Remove creature target type
-    ApplySpellFix({ 2641, 23356 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 2641, 23356 }, [](SpellInfo * spellInfo)
     {
         spellInfo->TargetCreatureType = 0;
     });
 
     // Aspect of the Viper
-    ApplySpellFix({ 34074 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34074 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(1);
@@ -4616,7 +4639,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Strength of Wrynn
-    ApplySpellFix({ 60509 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 60509 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].BasePoints = 1500;
         spellInfo->Effects[EFFECT_1].BasePoints = 150;
@@ -4624,13 +4647,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Playback Speech
-    ApplySpellFix({ 74209 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74209 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);
     });
 
     // Winterfin First Responder
-    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48739 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 1;
         spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 0;
@@ -4640,19 +4663,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Army of the Dead (trigger npc aura)
-    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48739 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 15000;
     });
 
     // Isle of Conquest - Teleport in, missing range
-    ApplySpellFix({ 48739 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48739 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 50000yd
     });
 
     // A'dal's Song of Battle
-    ApplySpellFix({ 39953 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 39953 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
@@ -4664,24 +4687,25 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Wintergrasp spells
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         57607, // Wintergrasp Catapult - Spell Plague Barrel - EffectRadiusIndex
         57619, // Wintergrasp Demolisher - Spell Hourl Boulder - EffectRadiusIndex
         57610  // Cannon (Siege Turret)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS); // SPELL_EFFECT_WMO_DAMAGE
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
     });
 
     // WintergraspCannon - Spell Fire Cannon - EffectRadiusIndex
-    ApplySpellFix({ 51422 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51422 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
     });
 
     // WintergraspDemolisher - Spell Ram -  EffectRadiusIndex
-    ApplySpellFix({ 54107 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54107 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_KNOCK_BACK
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
@@ -4689,7 +4713,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // WintergraspSiegeEngine - Spell Ram - EffectRadiusIndex
-    ApplySpellFix({ 51678 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51678 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_KNOCK_BACK
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // SPELL_EFFECT_SCHOOL_DAMAGE
@@ -4697,52 +4721,53 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // WintergraspCatapult - Spell Plague Barrell - Range
-    ApplySpellFix({ 57606 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57606 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(164); // "Catapult Range"
     });
 
     // Boulder (Demolisher)
-    ApplySpellFix({ 50999 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50999 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13); // 10yd
     });
 
     // Flame Breath (Catapult)
-    ApplySpellFix({ 50990 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50990 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(19); // 18yd
     });
 
     // Jormungar Bite
-    ApplySpellFix({ 50990 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50990 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
-    
+
     /////////////////////////////////
     ///// Generic NPC Spells
     /////////////////////////////////
 
     // Throw Proximity Bomb
-    ApplySpellFix({ 34095 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34095 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         53348, // DEATH KNIGHT SCARLET FIRE ARROW
         53117  // BALISTA
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->RecoveryTime = 5000;
         spellInfo->CategoryRecoveryTime = 5000;
     });
-    
+
     // Teleport To Molten Core
-    ApplySpellFix({ 25139 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 25139 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
     });
@@ -4757,21 +4782,21 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Shadowfang Keep
     // Landen Stilwell Transform
-    ApplySpellFix({ 31310 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31310 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
     });
 
     // Blackfathom Deeps
     // Shadowstalker Stealth
-    ApplySpellFix({ 5916 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 5916 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
     });
 
     // Maraudon
     // Sneak
-    ApplySpellFix({ 22766 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 22766 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
     });
@@ -4782,7 +4807,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Shadow Labirynth
     // Murmur's Touch
-    ApplySpellFix({ 38794, 33711 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 38794, 33711 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 33760;
@@ -4790,20 +4815,20 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // The Arcatraz
     // Negaton Field
-    ApplySpellFix({ 38794 /*Normal*/, 33711 /*Heroic*/ }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 38794 /*Normal*/, 33711 /*Heroic*/ }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Curse of the Doomsayer NORMAL
-    ApplySpellFix({ 36173 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 36173 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 36174; // Currently triggers heroic version...
     });
 
     // The Botanica
     // Crystal Channel
-    ApplySpellFix({ 34156 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34156 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(35); // 35yd;
         spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
@@ -4811,51 +4836,51 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Magtheridon's Lair
     // Debris
-    ApplySpellFix({ 36449 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 36449 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
     });
 
     // Soul Channel
-    ApplySpellFix({ 30531 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 30531 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
-    
+
     // Debris Visual
-    ApplySpellFix({ 30632 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 30632 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_ALLY);
     });
 
     // Sunwell Plateu
     // Activate Sunblade Protecto
-    ApplySpellFix({ 46475, 46476 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 46475, 46476 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(14); // 60yd
     });
 
     // Break Ice
-    ApplySpellFix({ 46638 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 46638 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 &= ~SPELL_ATTR3_ONLY_TARGET_PLAYERS; // Obvious fail, it targets gameobject...
     });
 
     // Sinister Reflection Clone
-    ApplySpellFix({ 45785 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45785 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 0.0f;
     });
 
     // Armageddon
-    ApplySpellFix({ 45909 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45909 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 8.0f;
     });
 
     // Black Temple
     // Spell Absorption
-    ApplySpellFix({ 41034 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41034 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_SCHOOL_ABSORB;
@@ -4864,47 +4889,47 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Shared Bonds
-    ApplySpellFix({ 41363 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41363 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
     });
 
     // Deadly Poison | Envenom
-    ApplySpellFix({ 41485, 41487 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41485, 41487 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
     });
 
     // Parasitic Shadowfiend
-    ApplySpellFix({ 41914 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41914 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Teleport Maiev
-    ApplySpellFix({ 41221 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41221 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
     });
 
     // Serpentshrine Cavern
     // Watery Grave Explosion
-    ApplySpellFix({ 37852 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 37852 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
     });
 
     // Karazhan
     // Amplify Damage
-    ApplySpellFix({ 39095 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 39095 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Magisters' Terrace
     // Energy Feedback
-    ApplySpellFix({ 44335 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 44335 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
     });
@@ -4913,16 +4938,17 @@ void SpellMgr::LoadSpellInfoCorrections()
         Raid: Battle for Mount Hyjal
         Boss: Archimonde
     */
-    ApplySpellFix({ 
-        31984, 
+    ApplySpellFix(
+    {
+        31984,
         35354  // Spell doesn't need to ignore invulnerabilities
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes = SPELL_ATTR0_ABILITY;
     });
 
     // We only need the animation, no damage
-    ApplySpellFix({ 32111 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 32111 }, [](SpellInfo * spellInfo)
     {
         spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(0);
     });
@@ -4930,15 +4956,15 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Vault of Archavon (VOA)
     //////////////////////////////////////////
-    
+
     // Flame Breath, catapult spell
-    ApplySpellFix({ 50989 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50989 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes &= ~SPELL_ATTR0_LEVEL_DAMAGE_CALCULATION;
     });
 
     // Koralon, Flaming Cinder missing radius index
-    ApplySpellFix({ 66690 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66690 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); //100yd
         spellInfo->MaxAffectedTargets = 1;
@@ -4947,40 +4973,40 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Naxxramas
     //////////////////////////////////////////
-    
+
     // Acid Volley
-    ApplySpellFix({ 54714, 29325 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54714, 29325 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Summon Plagued Warrior
-    ApplySpellFix({ 29237 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29237 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
     // Icebolt
-    ApplySpellFix({ 28526 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 28526 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
     // Infected Wound
-    ApplySpellFix({ 29306 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29306 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Hopeless
-    ApplySpellFix({ 29125 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29125 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
     });
 
     // Jagged Knife
-    ApplySpellFix({ 55550 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55550 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
     });
@@ -4988,19 +5014,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Gundrak
     //////////////////////////////////////////
-    
+
     // Moorabi - Transformation
-    ApplySpellFix({ 55098 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55098 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         55521, // Poisoned Spear (Normal)
         58967, // Poisoned Spear (Heroic)
         55348, // Throw (Normal)
-        58966  // Throw (Heroic) 
-    }, [](SpellInfo* spellInfo)
+        58966  // Throw (Heroic)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
     });
@@ -5008,9 +5035,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// The Nexus: Nexus
     //////////////////////////////////////////
-    
+
     // Charged Chaotic rift aura, trigger
-    ApplySpellFix({ 47737 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47737 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(37); // 50yd
     });
@@ -5018,9 +5045,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// AHN'KAHET: THE OLD KINGDOM
     //////////////////////////////////////////
-    
+
     // Vanish
-    ApplySpellFix({ 55964 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55964 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
         spellInfo->Effects[EFFECT_2].Effect = 0;
@@ -5029,61 +5056,62 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// DRAK'THARON KEEP
     //////////////////////////////////////////
-    
+
     // Trollgore - Summon Drakkari Invader
-    ApplySpellFix({ 49456, 49457, 49458 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49456, 49457, 49458 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
     });
 
     //////////////////////////////////////////
     ////////// UTGARDE PINNACLE
-    //////////////////////////////////////////    
-    
-    ApplySpellFix({ 
+    //////////////////////////////////////////
+
+    ApplySpellFix(
+    {
         48278, // Paralyse
         47669  // Awaken subboss
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Flame Breath
-    ApplySpellFix({ 47592 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47592 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 200;
     });
-    
+
     //////////////////////////////////////////
     ////////// UTGARDE KEEP
     //////////////////////////////////////////
-    
+
     // Skarvald, Charge
-    ApplySpellFix({ 43651 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 43651 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
     });
 
     // Ingvar the Plunderer, Woe Strike
-    ApplySpellFix({ 42730 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42730 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TriggerSpell = 42739;
     });
 
-    ApplySpellFix({ 59735 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59735 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TriggerSpell = 59736;
     });
 
     // Ingvar the Plunderer, Ingvar transform
-    ApplySpellFix({ 42796 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42796 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
     });
 
     // Hurl Dagger
-    ApplySpellFix({ 42772 /*Normal*/, 59685 /*Heroic*/ }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42772 /*Normal*/, 59685 /*Heroic*/ }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
     });
@@ -5091,22 +5119,22 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// VIOLET HOLD
     //////////////////////////////////////////
-    
+
     // Control Crystal Activation
-    ApplySpellFix({ 57804 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57804 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Destroy Door Seal
-    ApplySpellFix({ 58040 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 58040 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE);
     });
 
     // Ichoron, Water Blast
-    ApplySpellFix({ 54237, 59520 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54237, 59520 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
@@ -5116,7 +5144,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Krik'thir - Mind Flay
-    ApplySpellFix({ 52586, 59367 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52586, 59367 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
     });
@@ -5124,16 +5152,16 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// HALLS OF STONE
     //////////////////////////////////////////
-    
+
     // Glare of the Tribunal
-    ApplySpellFix({ 50988, 59870 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50988, 59870 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Static Charge
-    ApplySpellFix({ 50835, 59847 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50835, 59847 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
     });
@@ -5141,27 +5169,27 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// OBSIDIAN SANCTUM
     //////////////////////////////////////////
-    
+
     // Lava Strike damage
-    ApplySpellFix({ 57697 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57697 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
     });
 
     // Lava Strike trigger
-    ApplySpellFix({ 57578 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57578 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Gift of Twilight Shadow/Fire
-    ApplySpellFix({ 57835, 58766 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57835, 58766 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
     });
 
     // Pyrobuffet
-    ApplySpellFix({ 57557 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57557 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 56911;
     });
@@ -5169,9 +5197,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// EYE OF ETERNITY
     //////////////////////////////////////////
-    
+
     // Arcane Barrage
-    ApplySpellFix({ 56397 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56397 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5181,28 +5209,29 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
     });
 
-    ApplySpellFix({ 
-        55859, // Power Spark (ground +50% dmg aura) 
+    ApplySpellFix(
+    {
+        55859, // Power Spark (ground +50% dmg aura)
         56438  // Arcane Overload (-50% dmg taken) - this is to prevent apply -> unapply -> apply ... dunno whether it's correct
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Vortex (Control Vehicle)
-    ApplySpellFix({ 56263 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56263 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // Haste (Nexus Lord, increase run speed of the disk)
-    ApplySpellFix({ 57060 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57060 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_VEHICLE);
     });
 
     // Arcane Overload
-    ApplySpellFix({ 56430 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56430 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 56429;
@@ -5214,7 +5243,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
     });
 
-    ApplySpellFix({ 56429 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56429 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5225,7 +5254,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Destroy Platform Event
-    ApplySpellFix({ 59099 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59099 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(22);
         spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(15);
@@ -5234,7 +5263,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Surge of Power (Phase 3) | Normal and Heroic
-    ApplySpellFix({ 57407, 60936 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57407, 60936 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = (spellInfo->Id == 60936 ? 3 : 1);
         spellInfo->InterruptFlags = 0;
@@ -5246,7 +5275,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Wyrmrest Drake - Life Burst
-    ApplySpellFix({ 57143 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 57143 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(0);
@@ -5260,13 +5289,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Alexstrasza - Gift
-    ApplySpellFix({ 61028 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61028 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
     });
 
     // Vortex (freeze anim)
-    ApplySpellFix({ 55883 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55883 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
     });
@@ -5274,114 +5303,114 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// ULDUAR
     //////////////////////////////////////////
-    
+
     // Flame Leviathan
     // Hurl Pyrite
-    ApplySpellFix({ 62490 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62490 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Ulduar, Mimiron, Magnetic Core (summon)
-    ApplySpellFix({ 64444 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64444 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
     });
-    
+
     // Ulduar, Mimiron, bomb bot explosion
-    ApplySpellFix({ 63801 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63801 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].MiscValue = 17286;
     });
-    
+
     // Ulduar, Mimiron, Summon Flames Initial
-    ApplySpellFix({ 64563 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64563 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
-    
+
     // Ulduar, Mimiron, Flames (damage)
-    ApplySpellFix({ 64566 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64566 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
     });
 
     // Ulduar, Hodir, Starlight
-    ApplySpellFix({ 62807 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62807 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(16); // 1yd
     });
 
     // Ulduar, General Vezax, Mark of the Faceless
-    ApplySpellFix({ 63278 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63278 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
     });
 
     // XT-002 DECONSTRUCTOR
-    ApplySpellFix({ 62834 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62834 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // ASSEMBLY OF IRON
     // Supercharge
-    ApplySpellFix({ 61920 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61920 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Lightning Whirl
-    ApplySpellFix({ 61916 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61916 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 3;
     });
 
-    ApplySpellFix({ 63482 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63482 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 8;
     });
 
     // KOLOGARN
     // Stone Grip, remove absorb aura
-    ApplySpellFix({ 62056, 63985 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62056, 63985 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // AURIAYA
     // Sentinel Blast
-    ApplySpellFix({ 64389, 64678 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64389, 64678 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Dispel = DISPEL_MAGIC;
     });
 
     // FREYA
     // Potent Pheromones
-    ApplySpellFix({ 62619 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62619 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
     });
 
     // Healthy spore summon periodic
-    ApplySpellFix({ 62566 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62566 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 2000;
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
     });
 
     // Brightleaf Essence trigger
-    ApplySpellFix({ 62968 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62968 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0; // duplicate
     });
 
     // Potent Pheromones
-    ApplySpellFix({ 64321 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64321 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
         spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
@@ -5389,20 +5418,20 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // THORIM
     // charge obr stuff
-    ApplySpellFix({ 62186 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62186 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Amplitude = 5000; // Duration 5 secs, amplitude 8 secs...
     });
 
     // Charge Orb P2
-    ApplySpellFix({ 62976 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62976 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6);
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28);
     });
 
     // Sif's Blizzard
-    ApplySpellFix({ 62576, 62602 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62576, 62602 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
@@ -5410,38 +5439,38 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // YOGG-SARON
     // Protective Gaze
-    ApplySpellFix({ 64175 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64175 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RecoveryTime = 25000;
     });
 
     // Shadow Beacon
-    ApplySpellFix({ 64465 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 64465 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 64467; // why do they need two script effects :/ (this one has visual effect)
     });
 
     // Sanity
-    ApplySpellFix({ 63050 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63050 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
     });
 
     // Shadow Nova
-    ApplySpellFix({ 62714, 65209 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62714, 65209 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // ALGALON
     // Cosmic Smash (Algalon the Observer)
-    ApplySpellFix({ 62714, 65209 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62714, 65209 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
     });
 
     // Cosmic Smash (Algalon the Observer)
-    ApplySpellFix({ 62311, 64596 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62311, 64596 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
@@ -5449,20 +5478,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Constellation Phase Effect
-    ApplySpellFix({ 65509 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65509 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Black Hole
-    ApplySpellFix({ 62168, 65250, 62169 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62168, 65250, 62169 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
     });
 
     // TRASH
     // Ground Slam
-    ApplySpellFix({ 62625 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 62625 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
     });
@@ -5472,21 +5501,22 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Onyxia's Lair, Onyxia, Flame Breath (TriggerSpell = 0 and spamming errors in console)
-    ApplySpellFix({ 18435 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 18435 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Onyxia's Lair, Onyxia, Create Onyxia Spawner
-    ApplySpellFix({ 17647 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 17647 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(37);
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         17646, // Onyxia's Lair, Onyxia, Summon Onyxia Whelp
         68968  // Onyxia's Lair, Onyxia, Summon Lair Guard
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
@@ -5495,7 +5525,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Onyxia's Lair, Onyxia, Eruption:
-    ApplySpellFix({ 17731, 69294 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 17731, 69294 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(3);
@@ -5504,23 +5534,24 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Onyxia's Lair, Onyxia, Breath:
     // TODO: fix it by IconId / SpellVisual
-    ApplySpellFix({ 
-        18576, 18578, 18579, 18580, 18581, 18582, 18583, 18609, 18611, 
-        18612, 18613, 18614, 18615, 18616, 18584, 18585, 18586, 18587, 
-        18588, 18589, 18590, 18591, 18592, 18593, 18594, 18595, 18564, 
-        18565, 18566, 18567, 18568, 18569, 18570, 18571, 18572, 18573, 
-        18574, 18575, 18596, 18597, 18598, 18599, 18600, 18601, 18602, 
-        18603, 18604, 18605, 18606, 18607, 18617, 18619, 18620, 18621, 
-        18622, 18623, 18624, 18625, 18626, 18627, 18628, 18618, 18351, 
-        18352, 18353, 18354, 18355, 18356, 18357, 18358, 18359, 18360, 
-        18361, 17086, 17087, 17088, 17089, 17090, 17091, 17092, 17093, 
-        17094, 17095, 17097, 22267, 22268, 21132, 21133, 21135, 21136, 
-        21137, 21138, 21139 
-    }, [](SpellInfo* spellInfo)
+    ApplySpellFix(
+    {
+        18576, 18578, 18579, 18580, 18581, 18582, 18583, 18609, 18611,
+        18612, 18613, 18614, 18615, 18616, 18584, 18585, 18586, 18587,
+        18588, 18589, 18590, 18591, 18592, 18593, 18594, 18595, 18564,
+        18565, 18566, 18567, 18568, 18569, 18570, 18571, 18572, 18573,
+        18574, 18575, 18596, 18597, 18598, 18599, 18600, 18601, 18602,
+        18603, 18604, 18605, 18606, 18607, 18617, 18619, 18620, 18621,
+        18622, 18623, 18624, 18625, 18626, 18627, 18628, 18618, 18351,
+        18352, 18353, 18354, 18355, 18356, 18357, 18358, 18359, 18360,
+        18361, 17086, 17087, 17088, 17089, 17090, 17091, 17092, 17093,
+        17094, 17095, 17097, 22267, 22268, 21132, 21133, 21135, 21136,
+        21137, 21138, 21139
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(328); // 250ms
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(1);
-        
+
         if (spellInfo->Effects[EFFECT_1].Effect)
         {
             spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
@@ -5532,18 +5563,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// THE NEXUS: OCULUS
     //////////////////////////////////////////
-    
-    ApplySpellFix({ 
+
+    ApplySpellFix(
+    {
         48760,  // Oculus, Teleport to Coldarra DND
         49305   // Oculus, Teleport to Boss 1 DND
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(17);
     });
 
     // Oculus, Drake spell Stop Time
-    ApplySpellFix({ 49838 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49838 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
         spellInfo->ExcludeTargetAuraSpell = 51162; // exclude planar shift
@@ -5551,7 +5583,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Oculus, Varos Cloudstrider, Energize Cores
-    ApplySpellFix({ 61407, 62136, 56251, 54069 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 61407, 62136, 56251, 54069 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5560,15 +5592,15 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// HALLS OF LIGHTNING
     //////////////////////////////////////////
-    
+
     // Halls of Lightning, Arc Weld
-    ApplySpellFix({ 59086 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59086 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
     });
 
     // Halls of Lightning, Arcing Burn
-    ApplySpellFix({ 52671, 59834 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52671, 59834 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
@@ -5576,41 +5608,41 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// TRIAL OF THE CHAMPION
     //////////////////////////////////////////
-    
+
     // Trial of the Champion, Death's Respite
-    ApplySpellFix({ 68306 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68306 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(25);
     });
 
     // Trial of the Champion, Eadric Achievement (The Faceroller)
-    ApplySpellFix({ 68197 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68197 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
         spellInfo->Attributes |= SPELL_ATTR0_CASTABLE_WHILE_DEAD;
     });
 
     // Trial of the Champion, Earth Shield
-    ApplySpellFix({ 67530 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67530 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL; // will trigger 67537
     });
 
     // Trial of the Champion, Hammer of the Righteous
-    ApplySpellFix({ 66867 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66867 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
     });
 
     // Trial of the Champion, Summon Risen Jaeren/Arelas
-    ApplySpellFix({ 67705, 67715 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67705, 67715 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
     });
 
     // Trial of the Champion, Ghoul Explode
-    ApplySpellFix({ 67751 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67751 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
@@ -5624,7 +5656,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Champion, Desecration
-    ApplySpellFix({ 67778, 67877 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67778, 67877 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 68766;
     });
@@ -5632,9 +5664,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// TRIAL OF THE CRUSADER
     //////////////////////////////////////////
-    
+
     // Trial of the Crusader, Jaraxxus Intro spell
-    ApplySpellFix({ 67888 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67888 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
         spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
@@ -5642,13 +5674,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Crusader, Lich King Intro spell
-    ApplySpellFix({ 68193 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68193 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
     });
 
     // Trial of the Crusader, Gormok, player vehicle spell, CUSTOM! (default jump to hand, not used)
-    ApplySpellFix({ 66342 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66342 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_SET_VEHICLE_ID;
@@ -5661,7 +5693,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Crusader, Gormok, Fire Bomb
-    ApplySpellFix({ 66313 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66313 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
@@ -5673,14 +5705,14 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
-    ApplySpellFix({ 66317 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66317 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
         spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
-    ApplySpellFix({ 66318 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66318 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5690,37 +5722,37 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
-    ApplySpellFix({ 66320, 67472, 67473, 67475 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66320, 67472, 67473, 67475 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
     });
 
     // Trial of the Crusader, Acidmaw & Dreadscale, Emerge
-    ApplySpellFix({ 66947 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66947 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
     });
 
     // Trial of the Crusader, Jaraxxus, Curse of the Nether
-    ApplySpellFix({ 66211 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66211 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 66209; // exclude Touch of Jaraxxus
     });
 
     // Trial of the Crusader, Jaraxxus, Summon Volcano
-    ApplySpellFix({ 66258, 67901 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66258, 67901 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(85); // summon for 18 seconds, 15 not enough
     });
 
     // Trial of the Crusader, Jaraxxus, Spinning Pain Spike
-    ApplySpellFix({ 66281 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66281 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(26);
     });
 
-    ApplySpellFix({ 66287 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66287 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_TAUNT;
@@ -5732,50 +5764,50 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Crusader, Jaraxxus, Fel Fireball
-    ApplySpellFix({ 66532, 66963, 66964, 66965 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66532, 66963, 66964, 66965 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
     });
 
     // tempfix, make Nether Power not stealable
-    ApplySpellFix({ 66228, 67106, 67107, 67108 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66228, 67106, 67107, 67108 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
     });
 
     // Trial of the Crusader, Faction Champions, Druid - Tranquality
-    ApplySpellFix({ 66086, 67974, 67975, 67976 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66086, 67974, 67975, 67976 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
     });
 
     // Trial of the Crusader, Faction Champions, Shaman - Earth Shield
-    ApplySpellFix({ 66063 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66063 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 66064;
     });
 
     // Trial of the Crusader, Faction Champions, Priest - Mana Burn
-    ApplySpellFix({ 66100 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66100 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 5;
         spellInfo->Effects[EFFECT_0].DieSides = 0;
     });
 
-    ApplySpellFix({ 68026 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68026 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 8;
         spellInfo->Effects[EFFECT_0].DieSides = 0;
     });
 
-    ApplySpellFix({ 68027 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68027 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 6;
         spellInfo->Effects[EFFECT_0].DieSides = 0;
     });
 
-    ApplySpellFix({ 68028 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68028 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 10;
         spellInfo->Effects[EFFECT_0].DieSides = 0;
@@ -5783,7 +5815,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
     // Trial of the Crusader, Twin Valkyr, Touch of Light/Darkness, Light/Dark Surge
     // light 0
-    ApplySpellFix({ 65950 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65950 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5793,13 +5825,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // light surge 0
-    ApplySpellFix({ 65767 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65767 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 65686;
     });
 
     // light 1
-    ApplySpellFix({ 67296 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67296 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5809,13 +5841,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // light surge 1
-    ApplySpellFix({ 67274 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67274 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67222;
     });
 
     // light 2
-    ApplySpellFix({ 67297 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67297 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5825,13 +5857,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // light surge 2
-    ApplySpellFix({ 67275 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67275 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67223;
     });
 
     // light 3
-    ApplySpellFix({ 67298 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67298 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5841,13 +5873,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // light surge 3
-    ApplySpellFix({ 67276 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67276 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67224;
     });
 
     // Dark 0
-    ApplySpellFix({ 66001 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66001 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5857,13 +5889,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Dark surge 0
-    ApplySpellFix({ 65769 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65769 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 65684;
     });
 
     // Dark 1
-    ApplySpellFix({ 67281 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67281 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5873,13 +5905,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Dark surge 1
-    ApplySpellFix({ 67265 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67265 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67176;
     });
 
     // Dark 2
-    ApplySpellFix({ 67282 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67282 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5889,13 +5921,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Dark surge 2
-    ApplySpellFix({ 67266 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67266 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67177;
     });
 
     // Dark 3
-    ApplySpellFix({ 67283 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67283 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -5905,45 +5937,45 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Dark surge 3
-    ApplySpellFix({ 67267 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 67267 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 67178;
     });
 
     // Trial of the Crusader, Twin Valkyr, Twin's Pact
-    ApplySpellFix({ 65875, 67303, 67304, 67305, 65876, 67306, 67307, 67308 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65875, 67303, 67304, 67305, 65876, 67306, 67307, 67308 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
         spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
     // Trial of the Crusader, Anub'arak, Emerge
-    ApplySpellFix({ 65982 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65982 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
     });
 
     // Trial of the Crusader, Anub'arak, Penetrating Cold
-    ApplySpellFix({ 66013, 67700, 68509, 68510 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66013, 67700, 68509, 68510 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
     });
 
     // Trial of the Crusader, Anub'arak, Shadow Strike
-    ApplySpellFix({ 66134 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66134 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
         spellInfo->Effects[EFFECT_0].Effect = 0;
     });
 
     // Trial of the Crusader, Anub'arak, Pursuing Spikes
-    ApplySpellFix({ 65920, 65922, 65923 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65920, 65922, 65923 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
     });
 
     // Trial of the Crusader, Anub'arak, Summon Scarab
-    ApplySpellFix({ 66339 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66339 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35);
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
@@ -5951,10 +5983,11 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Crusader, Anub'arak, Achievements: The Traitor King
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         68186, // Anub'arak Scarab Achievement 10
         68515  // Anub'arak Scarab Achievement 25
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
@@ -5962,7 +5995,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trial of the Crusader, Anub'arak, Spider Frenzy
-    ApplySpellFix({ 66129 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 66129 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
@@ -5972,7 +6005,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Soul Sickness
-    ApplySpellFix({ 69131 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69131 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
         spellInfo->Effects[EFFECT_0].Amplitude = 8000;
@@ -5980,7 +6013,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Phantom Blast
-    ApplySpellFix({ 68982, 70322 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68982, 70322 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
     });
@@ -5990,40 +6023,42 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Empowered Blizzard
-    ApplySpellFix({ 70131 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70131 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
     });
 
     // Ice Lance Volley
-    ApplySpellFix({ 70464 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70464 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(25);
     });
 
-    ApplySpellFix({ 
-        70513, // Multi-Shot 
+    ApplySpellFix(
+    {
+        70513, // Multi-Shot
         59514  // Shriek of the Highborne
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Icicle
-    ApplySpellFix({ 69428, 69426 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69428, 69426 }, [](SpellInfo * spellInfo)
     {
         spellInfo->InterruptFlags = 0;
         spellInfo->AuraInterruptFlags = 0;
         spellInfo->ChannelInterruptFlags = 0;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         70525, // Jaina's Call
         70639  // Call of Sylvanas
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_1].Effect = 0;
@@ -6033,35 +6068,35 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Frost Nova
-    ApplySpellFix({ 68198 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68198 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
     });
 
     // Blight
-    ApplySpellFix({ 69604, 70286 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69604, 70286 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
         spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
     });
 
     // Chilling Wave
-    ApplySpellFix({ 68778, 70333 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68778, 70333 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Permafrost
-    ApplySpellFix({ 68786, 70336 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68786, 70336 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
         spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_DUMMY;
     });
 
     // Pursuit
-    ApplySpellFix({ 68987 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 68987 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -6073,37 +6108,37 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
-    ApplySpellFix({ 69029, 70850 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69029, 70850 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
     // Explosive Barrage
-    ApplySpellFix({ 69263 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69263 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_STUN;
     });
 
     // Overlord's Brand
-    ApplySpellFix({ 69172 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69172 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ProcFlags = DONE_HIT_PROC_FLAG_MASK & ~PROC_FLAG_DONE_PERIODIC;
         spellInfo->ProcChance = 100;
     });
 
     // Icy Blast
-    ApplySpellFix({ 69232 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69232 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TriggerSpell = 69238;
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
-    ApplySpellFix({ 69233, 69646 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69233, 69646 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
-    ApplySpellFix({ 69238, 69628 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69238, 69628 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
@@ -6113,13 +6148,13 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Hoarfrost
-    ApplySpellFix({ 69246, 69245, 69645 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69246, 69245, 69645 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // Devour Humanoid
-    ApplySpellFix({ 69503 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69503 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ChannelInterruptFlags |= 0;
         spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
@@ -6128,47 +6163,47 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// HALLS OF REFLECTION
     //////////////////////////////////////////
-    
+
     // Falric: Defiling Horror
-    ApplySpellFix({ 72435, 72452 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72435, 72452 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
     });
 
     // Frostsworn General - Throw Shield
-    ApplySpellFix({ 69222, 73076 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69222, 73076 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
     });
 
     // Halls of Reflection Clone
-    ApplySpellFix({ 69828 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69828 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
         spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
     // Summon Ice Wall
-    ApplySpellFix({ 69768 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69768 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
-    ApplySpellFix({ 69767 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69767 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
         spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
     // Essence of the Captured
-    ApplySpellFix({ 73035, 70719 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73035, 70719 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
     });
 
     // Achievement Check
-    ApplySpellFix({ 72830 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72830 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
     });
@@ -6177,7 +6212,8 @@ void SpellMgr::LoadSpellInfoCorrections()
     ////////// ICECROWN CITADEL
     //////////////////////////////////////////
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         70781, // Light's Hammer Teleport
         70856, // Oratory of the Damned Teleport
         70857, // Rampart of Skulls Teleport
@@ -6185,7 +6221,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         70859, // Upper Spire Teleport
         70860, // Frozen Throne Teleport
         70861  // Sindragosa's Lair Teleport
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -6195,28 +6231,29 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         70960, // Bone Flurry
         71258, // Adrenaline Rush (Ymirjar Battle-Maiden)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_2;
     });
 
     // Saber Lash (Lord Marrowgar)
-    ApplySpellFix({ 69055, 70814 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69055, 70814 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
     });
 
     // Impaled (Lord Marrowgar)
-    ApplySpellFix({ 69065 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69065 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0; // remove stun so Dispersion can be used
     });
 
     // Cold Flame (Lord Marrowgar)
-    ApplySpellFix({ 72701, 72702, 72703, 72704 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72701, 72702, 72703, 72704 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
@@ -6225,7 +6262,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Coldflame (Lord Marrowgar)
-    ApplySpellFix({ 69138 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69138 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
@@ -6233,19 +6270,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Coldflame (Lord Marrowgar)
-    ApplySpellFix({ 69146, 70823, 70824, 70825 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69146, 70823, 70824, 70825 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(15); // 3yd instead of 5yd
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
     });
 
     // Dark Martyrdom (Lady Deathwhisper)
-    ApplySpellFix({ 70897 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70897 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         69075, // Bone Storm (Lord Marrowgar)
         70834, // Bone Storm (Lord Marrowgar)
         70835, // Bone Storm (Lord Marrowgar)
@@ -6260,127 +6298,131 @@ void SpellMgr::LoadSpellInfoCorrections()
         71160, // Plague Stench (Stinky)
         71161, // Plague Stench (Stinky)
         71123, // Decimate (Stinky & Precious)
-        71464  // Divine Surge (Sister Svalna) 
-    }, [](SpellInfo* spellInfo)
+        71464  // Divine Surge (Sister Svalna)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12);   // 100yd
     });
 
     // Shadow's Fate
-    ApplySpellFix({ 71169 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71169 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
     // Lock Players and Tap Chest
-    ApplySpellFix({ 72347 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72347 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 &= ~SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Award Reputation - Boss Kill
-    ApplySpellFix({ 73843, 73844, 73845, 73846 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73843, 73844, 73845, 73846 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);
     });
 
     // Death Plague (Rotting Frost Giant)
-    ApplySpellFix({ 72864 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72864 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 0;
     });
 
     // Gunship Battle, spell Below Zero
-    ApplySpellFix({ 72864 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72864 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // Resistant Skin (Deathbringer Saurfang adds)
-    ApplySpellFix({ 72723 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72723 }, [](SpellInfo * spellInfo)
     {
         // this spell initially granted Shadow damage immunity, however it was removed but the data was left in client
         spellInfo->Effects[EFFECT_2].Effect = 0;
     });
 
-    // Mark of the Fallen Champion (Deathbringer Saurfang) 
+    // Mark of the Fallen Champion (Deathbringer Saurfang)
     // Patch 3.3.2 (2010-01-02): Deathbringer Saurfang will no longer gain blood power from Mark of the Fallen Champion.
     // Xinef: prevented in script, effect needed for Prayer of Mending
-    ApplySpellFix({ 72255, 72444, 72445, 72446 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72255, 72444, 72445, 72446 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
     });
 
     // Coldflame Jets (Traps after Saurfang)
-    ApplySpellFix({ 70460 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70460 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);  // 10 seconds
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         70461, // Coldflame Jets (Traps after Saurfang)
         71289  // Dominate Mind (Lady Deathwhisper)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // Severed Essence (Val'kyr Herald)
-    ApplySpellFix({ 71906, 71942 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71906, 71942 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         71159, // Awaken Plagued Zombies (Precious)
         71302  // Awaken Ymirjar Fallen (Ymirjar Deathbringer)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
     });
 
     // Blood Prince Council, Invocation of Blood
-    ApplySpellFix({ 70981, 70982, 70952 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70981, 70982, 70952 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0; // clear share health aura
     });
 
     // Ymirjar Frostbinder, Frozen Orb
-    ApplySpellFix({ 71274 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71274 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
     });
 
     // Ooze Flood (Rotface)
-    ApplySpellFix({ 69783, 69797, 69799, 69802 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69783, 69797, 69799, 69802 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_CANT_TARGET_SELF;
     });
 
     // Volatile Ooze Beam Protection
-    ApplySpellFix({ 70530 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70530 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA; // blizzard typo, 65 instead of 6, aura itself is defined (dummy)
     });
 
     // Professor Putricide, Gaseous Bloat (Orange Ooze Channel) -- copied attributes from Green Ooze Channel
-    ApplySpellFix({ 70672, 72455, 72832, 72833 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70672, 72455, 72832, 72833 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         71412, // Green Ooze Summon (Professor Putricide)
         71415  // Orange Ooze Summon (Professor Putricide)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         71621,
         72850,
         72851,
@@ -6389,101 +6431,104 @@ void SpellMgr::LoadSpellInfoCorrections()
         73120,
         73121,
         73122  // Guzzle Potions (Professor Putricide)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(15); // 4 sec
     });
 
     // Mutated Plague (Professor Putricide)
-    ApplySpellFix({ 72454, 72464, 72506, 72507 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72454, 72464, 72506, 72507 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
     // Unbound Plague (Professor Putricide) (needs target selection script)
-    ApplySpellFix({ 70911, 72854, 72855, 72856 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70911, 72854, 72855, 72856 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
     });
 
     // Mutated Transformation (Professor Putricide)
-    ApplySpellFix({ 70402, 72511, 72512, 72513 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70402, 72511, 72512, 72513 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
     });
 
     // Empowered Flare (Blood Prince Council)
-    ApplySpellFix({ 71708, 72785, 72786, 72787 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71708, 72785, 72786, 72787 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
-    
-    ApplySpellFix({ 
+
+    ApplySpellFix(
+    {
         71518, // Unholy Infusion Quest Credit (Professor Putricide)
         72934, // Blood Infusion Quest Credit (Blood-Queen Lana'thel)
         72289  // Frost Infusion Quest Credit (Sindragosa)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // another missing radius
     });
 
     // Swarming Shadows
-    ApplySpellFix({ 71266, 72890 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71266, 72890 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AreaGroupId = 0; // originally, these require area 4522, which is... outside of Icecrown Citadel
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         71301, // Summon Dream Portal (Valithria Dreamwalker)
         71977  // Summon Nightmare Portal (Valithria Dreamwalker)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Column of Frost (visual marker)
-    ApplySpellFix({ 70715 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70715 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(32); // 6 seconds (missing)
     });
 
     // Mana Void (periodic aura)
-    ApplySpellFix({ 71085 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71085 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 seconds (missing)
     });
 
     // Summon Suppressor (needs target selection script)
-    ApplySpellFix({ 70936 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70936 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Corruption
-    ApplySpellFix({ 70602 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70602 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         72706, // Achievement Check (Valithria Dreamwalker)
         71357  // Achievement Check (Valithria Dreamwalker)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
     });
 
     // Sindragosa's Fury
-    ApplySpellFix({ 70598 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70598 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
     });
 
     // Tail Smash (Sindragosa)
-    ApplySpellFix({ 71077 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71077 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER_BACK);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
@@ -6492,79 +6537,81 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Frost Bomb
-    ApplySpellFix({ 69846 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69846 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 0.0f;    // This spell's summon happens instantly
     });
 
     // Mystic Buffet (Sindragosa) - remove obsolete spell effect with no targets
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         70127,
         72528,
         72529,
         72530
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Sindragosa, Frost Aura
-    ApplySpellFix({ 70084, 71050, 71051, 71052 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70084, 71050, 71051, 71052 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
     });
 
     // Ice Lock
-    ApplySpellFix({ 71614 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71614 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Mechanic = MECHANIC_STUN;
     });
 
     // Lich King, Infest
-    ApplySpellFix({ 70541, 73779, 73780, 73781 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70541, 73779, 73780, 73781 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // Lich King, Necrotic Plague
-    ApplySpellFix({ 70337, 73912, 73913, 73914, 70338, 73785, 73786, 73787 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70337, 73912, 73913, 73914, 70338, 73785, 73786, 73787 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
     });
 
     // Ice Pulse
-    ApplySpellFix({ 69099, 73776, 73777, 73778 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69099, 73776, 73777, 73778 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
     });
 
     // Fury of Frostmourne
-    ApplySpellFix({ 72350 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72350 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         72351, // Fury of Frostmourne
         72431, // Jump (removes Fury of Frostmourne debuff)
         72429, // Mass Resurrection
-        73159  // Play Movie 
-    }, [](SpellInfo* spellInfo)
+        73159  // Play Movie
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
     // Raise Dead
-    ApplySpellFix({ 72376 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72376 }, [](SpellInfo * spellInfo)
     {
         spellInfo->MaxAffectedTargets = 4;
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
     // Jump
-    ApplySpellFix({ 71809 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71809 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(5); // 40yd
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // 10yd
@@ -6572,31 +6619,31 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Broken Frostmourne
-    ApplySpellFix({ 72405 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72405 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
     });
 
     // Summon Shadow Trap
-    ApplySpellFix({ 73540 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73540 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(3);  // 60 seconds
     });
 
     // Shadow Trap (visual)
-    ApplySpellFix({ 73530 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73530 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28); // 5 seconds
     });
 
     // Shadow Trap
-    ApplySpellFix({ 73529 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73529 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);   // 10yd
     });
 
     // Raging Spirit Visual
-    ApplySpellFix({ 69198 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69198 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);             // 50000yd
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
@@ -6604,7 +6651,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Defile
-    ApplySpellFix({ 72762 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72762 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(559); // 53 seconds
         spellInfo->ExcludeCasterAuraSpell = 0;
@@ -6613,20 +6660,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Defile
-    ApplySpellFix({ 72743 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72743 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(22); // 45 seconds
     });
 
     // Defile
-    ApplySpellFix({ 72754, 73708, 73709, 73710 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72754, 73708, 73709, 73710 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
     });
 
     // Val'kyr Target Search
-    ApplySpellFix({ 69030 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 69030 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
@@ -6634,7 +6681,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Harvest Souls
-    ApplySpellFix({ 73654, 74295, 74296, 74297 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73654, 74295, 74296, 74297 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
@@ -6642,63 +6689,63 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Restore Soul
-    ApplySpellFix({ 72595, 73650 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72595, 73650 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
     });
 
     // Kill Frostmourne Players
-    ApplySpellFix({ 75127 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75127 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
     // Harvest Soul
-    ApplySpellFix({ 73655 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73655 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
     });
 
     // Destroy Soul
-    ApplySpellFix({ 74086 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74086 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
     });
 
     // Summon Spirit Bomb
-    ApplySpellFix({ 74302, 74342 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74302, 74342 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
         spellInfo->MaxAffectedTargets = 1;
     });
 
     // Summon Spirit Bomb
-    ApplySpellFix({ 74341, 74343 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74341, 74343 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
         spellInfo->MaxAffectedTargets = 3;
     });
 
     // Summon Spirit Bomb
-    ApplySpellFix({ 73579 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73579 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS);   // 25yd
     });
 
     // Trigger Vile Spirit (Inside, Heroic)
-    ApplySpellFix({ 73582 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73582 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
     });
 
     // Scale Aura (used during Dominate Mind from Lady Deathwhisper)
-    ApplySpellFix({ 73261 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 73261 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
     });
 
     // Leap to a Random Location
-    ApplySpellFix({ 70485 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70485 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
@@ -6706,7 +6753,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Empowered Blood
-    ApplySpellFix({ 70227, 70232 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 70227, 70232 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AreaGroupId = 2452; // Whole icc instead of Crimson Halls only, remove when area calculation is fixed
     });
@@ -6714,51 +6761,52 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// RUBY SANCTUN
     //////////////////////////////////////////
-    
+
     // Repelling Wave
-    ApplySpellFix({ 74509 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74509 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
     });
 
     // Rallying Shout
-    ApplySpellFix({ 75414 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75414 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
     });
 
     // Barrier Channel
-    ApplySpellFix({ 76221 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 76221 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_TURNING | AURA_INTERRUPT_FLAG_MOVE);
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
     });
 
     // Intimidating Roar
-    ApplySpellFix({ 74384 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74384 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         74562, // Fiery Combustion
         74792  // Soul Consumption
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
     });
 
     // Combustion
-    ApplySpellFix({ 75883, 75884 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75883, 75884 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
     });
 
     // Consumption
-    ApplySpellFix({ 75875, 75876 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75875, 75876 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
@@ -6767,19 +6815,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Soul Consumption
-    ApplySpellFix({ 74799 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74799 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_12_YARDS);
     });
 
     // Twilight Cutter
-    ApplySpellFix({ 74769, 77844, 77845, 77846 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74769, 77844, 77845, 77846 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
     });
 
     // Twilight Mending
-    ApplySpellFix({ 75509 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75509 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
@@ -6788,21 +6836,22 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Meteor Strike
-    ApplySpellFix({ 74637 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74637 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Speed = 0;
     });
 
     // Blazing Aura
-    ApplySpellFix({ 75885, 75886 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 75885, 75886 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         75952, // Meteor Strike
         74629  // Combustion Periodic
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
     });
@@ -6812,7 +6861,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     // ///////////////////////////////////////////
 
     // Going Bearback (12851)
-    ApplySpellFix({ 54897 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 54897 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
@@ -6821,80 +6870,81 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Still At It (12644)
-    ApplySpellFix({ 51931, 51932, 51933 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51931, 51932, 51933 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(38);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Rallying the Troops (12070)
-    ApplySpellFix({ 47394 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47394 }, [](SpellInfo * spellInfo)
     {
         spellInfo->ExcludeTargetAuraSpell = 47394;
     });
 
     // A Tangled Skein (12555)
-    ApplySpellFix({ 51165, 51173 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 51165, 51173 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // A Cloudlet of Classy Cologne (24635)
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         69563, // A Cloudlet of Classy Cologne (24635)
         69445, // A Perfect Puff of Perfume (24629)
         69489  // Bonbon Blitz (24636)
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Control (9595)
-    ApplySpellFix({ 30790 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 30790 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].MiscValue = 0;
     });
 
     // Reclusive Runemaster (12150)
-    ApplySpellFix({ 48028 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 48028 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
     });
 
     // Mastery of
-    ApplySpellFix({ 65147 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65147 }, [](SpellInfo * spellInfo)
     {
         spellInfo->CategoryEntry = sSpellCategoryStore.LookupEntry(1244);
         spellInfo->CategoryRecoveryTime = 1500;
     });
 
     // Weakness to Lightning (11896)
-    ApplySpellFix({ 46432 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 46432 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 &= ~SPELL_ATTR3_DEATH_PERSISTENT;
     });
 
     // Wrangle Some Aether Rays! (11065)
-    ApplySpellFix({ 40856 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40856 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(27); // 3000ms
     });
 
     // The Black Knight's Orders (13663)
-    ApplySpellFix({ 63163 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 63163 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 52390;
     });
 
     // The Warp Rifts (10278)
-    ApplySpellFix({ 34888 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 34888 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(5); // 300 secs
     });
 
     // The Smallest Creatures (10720)
-    ApplySpellFix({ 38544 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 38544 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValueB = 427;
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
@@ -6902,39 +6952,39 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Ridding the red rocket
-    ApplySpellFix({ 49177 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 49177 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 1; // corrects seat id (points - 1 = seatId)
     });
 
     // The Iron Colossus (13007)
-    ApplySpellFix({ 56513, 56524 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56513, 56524 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RecoveryTime = (spellInfo->Id == 56524 ? 6000 : 2000);
     });
 
     // Kaw the Mammoth Destroyer (11879)
-    ApplySpellFix({ 46260 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 46260 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
 
     // That's Abominable (13264, 13276, 13288, 13289)
-    ApplySpellFix({ 59565 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59565 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValueB = 1721; // controlable guardian
     });
 
     // Investigate the Blue Recluse (1920)
     // Investigate the Alchemist Shop (1960)
-    ApplySpellFix({ 9095 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 9095 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13);
     });
 
     // Dragonmaw Race: All parts
-    ApplySpellFix({ 40890 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40890 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
@@ -6943,7 +6993,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Trope's Slime Cannon
-    ApplySpellFix({ 40909 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40909 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
@@ -6952,7 +7002,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Corlok's Skull Barrage
-    ApplySpellFix({ 40894 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40894 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 40900;
@@ -6961,7 +7011,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Ichman's Blazing Fireball
-    ApplySpellFix({ 40928 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40928 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 40929;
@@ -6970,7 +7020,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Mulverick's Great Balls of Lightning
-    ApplySpellFix({ 40930 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40930 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 40931;
@@ -6979,7 +7029,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Sky Shatter
-    ApplySpellFix({ 40945 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 40945 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 41064;
@@ -6988,92 +7038,92 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Gauging the Resonant Frequency (10594)
-    ApplySpellFix({ 37390 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 37390 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValueB = 181;
     });
 
     // Where in the World is Hemet Nesingwary? (12521)
-    ApplySpellFix({ 50860 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50860 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 50860;
     });
 
-    ApplySpellFix({ 50861 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 50861 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 0;
     });
 
     // Krolmir, Hammer of Storms (13010)
-    ApplySpellFix({ 56606, 56541 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 56606, 56541 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 1;
     });
 
     // Blightbeasts be Damned! (12072)
-    ApplySpellFix({ 47424 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47424 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AuraInterruptFlags &= ~AURA_INTERRUPT_FLAG_NOT_ABOVEWATER;
     });
 
     // Leading the Charge (13380), All Infra-Green bomber quests
-    ApplySpellFix({ 59059 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59059 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
     });
 
     // Dark Horizon (12664), Reunited (12663)
-    ApplySpellFix({ 52190 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52190 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = 52391 - 1;
     });
 
     // The Sum is Greater than the Parts (13043) - Chained Grip
-    ApplySpellFix({ 60540 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 60540 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].MiscValue = 300;
     });
 
     // Not a Bug (13342)
-    ApplySpellFix({ 60531 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 60531 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
     });
 
     // Frankly,  It Makes No Sense... (10672)
-    ApplySpellFix({ 37851 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 37851 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Honor Challenge (12939)
-    ApplySpellFix({ 21855 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 21855 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
     });
 
     // Convocation at Zol'Heb (12730)
-    ApplySpellFix({ 52956 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 52956 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENTRY);
     });
 
     // Mangletooth Quests (http://www.wowhead.com/npc=3430)
-    ApplySpellFix({ 7764, 10767, 16610, 16612, 16618, 17013 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 7764, 10767, 16610, 16612, 16618, 17013 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
         spellInfo->AttributesEx5 |= SPELL_ATTR5_SKIP_CHECKCAST_LOS_CHECK;
     });
 
     // Crushing the Crown
-    ApplySpellFix({ 71024 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71024 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
     });
 
     // Battle for the Undercity
     // Cyclone fall
-    ApplySpellFix({ 59892 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59892 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
@@ -7086,118 +7136,119 @@ void SpellMgr::LoadSpellInfoCorrections()
     // ///////////////////////////////////////////
 
     // Enchant Lightweave Embroidery
-    ApplySpellFix({ 55637 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 55637 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].MiscValue = 126;
     });
 
     // Magic Broom
-    ApplySpellFix({ 47977 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47977 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
         spellInfo->Effects[EFFECT_1].Effect = 0;
     });
 
     // Titanium Seal of Dalaran, Toss your luck
-    ApplySpellFix({ 60476 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 60476 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
     });
 
     // Mind Amplification Dish, change charm aura
-    ApplySpellFix({ 26740 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 26740 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_CHARM;
     });
 
     // Persistent Shield (fixes idiocity)
-    ApplySpellFix({ 26467 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 26467 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE;
         spellInfo->Effects[EFFECT_0].TriggerSpell = 26470;
     });
 
     // Deadly Swiftness
-    ApplySpellFix({ 31255 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 31255 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TriggerSpell = 22588;
     });
 
     // Black Magic enchant
-    ApplySpellFix({ 59630 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 59630 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
     });
 
     // Precious's Ribbon
-    ApplySpellFix({ 72968 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72968 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
     });
 
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         71646, // Item - Bauble of True Blood 10m
         71607, // Item - Bauble of True Blood 25m
         71610, // Item - Althor's Abacus trigger 10m
         71641  // Item - Althor's Abacus trigger 25m
-    }, [](SpellInfo* spellInfo)
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
         spellInfo->SpellLevel = 0;
     });
 
     // Drain Life - Bryntroll Normal / Heroic
-    ApplySpellFix({ 71838, 71839 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 71838, 71839 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
         spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
     });
 
     // Alchemist's Stone
-    ApplySpellFix({ 17619 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 17619 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
     });
 
     // Gnomish Death Ray
-    ApplySpellFix({ 13278, 13280 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 13278, 13280 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
     });
 
     // Stormchops
-    ApplySpellFix({ 43730 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 43730 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(1);
         spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
     });
 
     // Savory Deviate Delight (transformations), allow to mount while transformed
-    ApplySpellFix({ 8219, 8220, 8221, 8222 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 8219, 8220, 8221, 8222 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
     });
 
     // Clamlette Magnifique
-    ApplySpellFix({ 72623 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 72623 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].BasePoints = spellInfo->Effects[EFFECT_1].BasePoints;
     });
 
     // Compact Harvest Reaper
-    ApplySpellFix({ 4078 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 4078 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(6); // 10 minutes
     });
 
     // Dragon Kite, Tuskarr Kite - Kite String
-    ApplySpellFix({ 45192 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45192 }, [](SpellInfo * spellInfo)
     {
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
     });
 
     // Frigid Frostling, Infrigidate
-    ApplySpellFix({ 74960 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 74960 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(9); // 20yd
     });
@@ -7211,7 +7262,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Apple Trap
-    ApplySpellFix({ 43450 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 43450 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
@@ -7219,19 +7270,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Dark Iron Attack - spawn mole machine
-    ApplySpellFix({ 43563 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 43563 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].Effect = 0; // summon GO's manually
     });
 
     // Throw Mug visual
-    ApplySpellFix({ 42300 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42300 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
     // Dark Iron knockback Aura
-    ApplySpellFix({ 42299 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42299 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_DUMMY;
         spellInfo->Effects[EFFECT_0].MiscValue = 100;
@@ -7239,7 +7290,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Chug and Chuck!
-    ApplySpellFix({ 42436 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42436 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
@@ -7248,19 +7299,19 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Catch the Wild Wolpertinger!
-    ApplySpellFix({ 41621 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 41621 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
     });
 
     // Brewfest quests
-    ApplySpellFix({ 47134, 51798 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 47134, 51798 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
     });
 
     // The Heart of The Storms (12998)
-    ApplySpellFix({ 43528 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 43528 }, [](SpellInfo * spellInfo)
     {
         spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(18);
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
@@ -7271,20 +7322,20 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
 
     // Water splash
-    ApplySpellFix({ 42348 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42348 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].Effect = 0;
     });
 
     // Summon Lantersn
-    ApplySpellFix({ 44255, 44231 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 44255, 44231 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
     });
 
     // Throw Head Back
-    ApplySpellFix({ 42401 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 42401 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
@@ -7293,29 +7344,29 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Pilgrim's Bounty
     //////////////////////////////////////////
-    
+
     // Various food
-    ApplySpellFix({ 65418 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65418 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TriggerSpell = 65410;
     });
 
-    ApplySpellFix({ 65422 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65422 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TriggerSpell = 65414;
     });
 
-    ApplySpellFix({ 65419 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65419 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TriggerSpell = 65416;
     });
 
-    ApplySpellFix({ 65420 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65420 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TriggerSpell = 65412;
     });
 
-    ApplySpellFix({ 65421 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 65421 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_2].TriggerSpell = 65415;
     });
@@ -7323,9 +7374,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Midsummer
     //////////////////////////////////////////
-    
+
     // Stamp Out Bonfire
-    ApplySpellFix({ 45437 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 45437 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
@@ -7333,7 +7384,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Light Bonfire (DND)
-    ApplySpellFix({ 29831 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 29831 }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
     });
@@ -7341,9 +7392,9 @@ void SpellMgr::LoadSpellInfoCorrections()
     //////////////////////////////////////////
     ////////// Misc Events
     //////////////////////////////////////////
-    
+
     // Infernal
-    ApplySpellFix({ 33240 }, [](SpellInfo* spellInfo)
+    ApplySpellFix({ 33240 }, [](SpellInfo * spellInfo)
     {
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
         spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
@@ -7351,17 +7402,18 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Check for SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER
-    ApplySpellFix({ 
+    ApplySpellFix(
+    {
         47476, // Deathknight - Strangulate
         15487, // Priest - Silence
         5211,  // Druid - Bash  - R1
         6798,  // Druid - Bash  - R2
-        8983   // Druid - Bash  - R3 
-    }, [](SpellInfo* spellInfo)
+        8983   // Druid - Bash  - R3
+    }, [](SpellInfo * spellInfo)
     {
         spellInfo->AttributesEx7 |= SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER;
     });
-    
+
     for (auto spellInfo : mSpellInfoMap)
     {
         for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
@@ -7392,7 +7444,7 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         if (spellInfo->ActiveIconID == 2158) // flight
             spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
-        
+
         switch (spellInfo->SpellFamilyName)
         {
             case SPELLFAMILY_PALADIN:
@@ -7424,7 +7476,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     properties->Type = SUMMON_TYPE_TOTEM;
     properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(647)); // 52893
     properties->Type = SUMMON_TYPE_TOTEM;
-    
+
     if ((properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(628)))) // Hungry Plaguehound
     {
         properties->Category = SUMMON_CATEGORY_PET;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2680,7 +2680,7 @@ void SpellMgr::UnloadSpellInfoStore()
         if (mSpellInfoMap[i])
             delete mSpellInfoMap[i];
     }
-    
+
     mSpellInfoMap.clear();
 }
 
@@ -3302,9 +3302,9 @@ void SpellMgr::LoadSpellInfoCorrections()
         {
             auto _spellEntry = (SpellEntry*)sSpellStore.LookupEntry(i);
             for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
-            if (_spellEntry->rangeIndex == 1 && (_spellEntry->EffectImplicitTargetA[j] == TARGET_DEST_TRAJ || _spellEntry->EffectImplicitTargetB[j] == TARGET_DEST_TRAJ))
-                if (SpellEntry* spellInfo2 = (SpellEntry*)sSpellStore.LookupEntry(_spellEntry->EffectTriggerSpell[j]))
-                    spellInfo2->rangeIndex = 187; // 300yd
+                if (_spellEntry->rangeIndex == 1 && (_spellEntry->EffectImplicitTargetA[j] == TARGET_DEST_TRAJ || _spellEntry->EffectImplicitTargetB[j] == TARGET_DEST_TRAJ))
+                    if (SpellEntry* spellInfo2 = (SpellEntry*)sSpellStore.LookupEntry(_spellEntry->EffectTriggerSpell[j]))
+                        spellInfo2->rangeIndex = 187; // 300yd
         }
 
         if (spellInfo->ActiveIconID == 2158)  // flight

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4762,6 +4762,2271 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
     });
 
+    // Blackfathom Deeps
+    // Shadowstalker Stealth
+    ApplySpellFix({ 5916 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
+    });
+
+    // Maraudon
+    // Sneak
+    ApplySpellFix({ 22766 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
+    });
+
+    //////////////////////////////////////////
+    ////////// TBC Instances
+    //////////////////////////////////////////
+
+    // Shadow Labirynth
+    // Murmur's Touch
+    ApplySpellFix({ 38794, 33711 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 33760;
+    });
+
+    // The Arcatraz
+    // Negaton Field
+    ApplySpellFix({ 38794 /*Normal*/, 33711 /*Heroic*/ }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Curse of the Doomsayer NORMAL
+    ApplySpellFix({ 36173 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 36174; // Currently triggers heroic version...
+    });
+
+    // The Botanica
+    // Crystal Channel
+    ApplySpellFix({ 34156 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(35); // 35yd;
+        spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
+    });
+
+    // Magtheridon's Lair
+    // Debris
+    ApplySpellFix({ 36449 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+    });
+
+    // Soul Channel
+    ApplySpellFix({ 30531 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+    
+    // Debris Visual
+    ApplySpellFix({ 30632 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_ALLY);
+    });
+
+    // Sunwell Plateu
+    // Activate Sunblade Protecto
+    ApplySpellFix({ 46475, 46476 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(14); // 60yd
+    });
+
+    // Break Ice
+    ApplySpellFix({ 46638 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 &= ~SPELL_ATTR3_ONLY_TARGET_PLAYERS; // Obvious fail, it targets gameobject...
+    });
+
+    // Sinister Reflection Clone
+    ApplySpellFix({ 45785 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0.0f;
+    });
+
+    // Armageddon
+    ApplySpellFix({ 45909 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 8.0f;
+    });
+
+    // Black Temple
+    // Spell Absorption
+    ApplySpellFix({ 41034 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_SCHOOL_ABSORB;
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_2].MiscValue = SPELL_SCHOOL_MASK_MAGIC;
+    });
+
+    // Shared Bonds
+    ApplySpellFix({ 41363 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
+    });
+
+    // Deadly Poison | Envenom
+    ApplySpellFix({ 41485, 41487 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+    });
+
+    // Parasitic Shadowfiend
+    ApplySpellFix({ 41914 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Teleport Maiev
+    ApplySpellFix({ 41221 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
+    });
+
+    // Serpentshrine Cavern
+    // Watery Grave Explosion
+    ApplySpellFix({ 37852 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
+    });
+
+    // Karazhan
+    // Amplify Damage
+    ApplySpellFix({ 39095 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // Magisters' Terrace
+    // Energy Feedback
+    ApplySpellFix({ 44335 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
+    /*
+        Raid: Battle for Mount Hyjal
+        Boss: Archimonde
+    */
+    ApplySpellFix({ 
+        31984, 
+        35354  // Spell doesn't need to ignore invulnerabilities
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes = SPELL_ATTR0_ABILITY;
+    });
+
+    // We only need the animation, no damage
+    ApplySpellFix({ 32111 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(0);
+    });
+
+    //////////////////////////////////////////
+    ////////// Vault of Archavon (VOA)
+    //////////////////////////////////////////
+    
+    // Flame Breath, catapult spell
+    ApplySpellFix({ 50989 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes &= ~SPELL_ATTR0_LEVEL_DAMAGE_CALCULATION;
+    });
+
+    // Koralon, Flaming Cinder missing radius index
+    ApplySpellFix({ 66690 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); //100yd
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    //////////////////////////////////////////
+    ////////// Naxxramas
+    //////////////////////////////////////////
+    
+    // Acid Volley
+    ApplySpellFix({ 54714, 29325 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // Summon Plagued Warrior
+    ApplySpellFix({ 29237 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Icebolt
+    ApplySpellFix({ 28526 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    // Infected Wound
+    ApplySpellFix({ 29306 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Hopeless
+    ApplySpellFix({ 29125 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+    });
+
+    // Jagged Knife
+    ApplySpellFix({ 55550 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
+    });
+
+    //////////////////////////////////////////
+    ////////// Gundrak
+    //////////////////////////////////////////
+    
+    // Moorabi - Transformation
+    ApplySpellFix({ 55098 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+    });
+
+    ApplySpellFix({ 
+        55521, // Poisoned Spear (Normal)
+        58967, // Poisoned Spear (Heroic)
+        55348, // Throw (Normal)
+        58966  // Throw (Heroic) 
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
+    });
+
+    //////////////////////////////////////////
+    ////////// The Nexus: Nexus
+    //////////////////////////////////////////
+    
+    // Charged Chaotic rift aura, trigger
+    ApplySpellFix({ 47737 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(37); // 50yd
+    });
+
+    //////////////////////////////////////////
+    ////////// AHN'KAHET: THE OLD KINGDOM
+    //////////////////////////////////////////
+    
+    // Vanish
+    ApplySpellFix({ 55964 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    //////////////////////////////////////////
+    ////////// DRAK'THARON KEEP
+    //////////////////////////////////////////
+    
+    // Trollgore - Summon Drakkari Invader
+    ApplySpellFix({ 49456, 49457, 49458 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
+    });
+
+    //////////////////////////////////////////
+    ////////// UTGARDE PINNACLE
+    //////////////////////////////////////////    
+    
+    ApplySpellFix({ 
+        48278, // Paralyse
+        47669  // Awaken subboss
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Flame Breath
+    ApplySpellFix({ 47592 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Amplitude = 200;
+    });
+    
+    //////////////////////////////////////////
+    ////////// UTGARDE KEEP
+    //////////////////////////////////////////
+    
+    // Skarvald, Charge
+    ApplySpellFix({ 43651 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
+    });
+
+    // Ingvar the Plunderer, Woe Strike
+    ApplySpellFix({ 42730 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TriggerSpell = 42739;
+    });
+
+    ApplySpellFix({ 59735 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TriggerSpell = 59736;
+    });
+
+    // Ingvar the Plunderer, Ingvar transform
+    ApplySpellFix({ 42796 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
+    });
+
+    // Hurl Dagger
+    ApplySpellFix({ 42772 /*Normal*/, 59685 /*Heroic*/ }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
+    });
+
+    //////////////////////////////////////////
+    ////////// VIOLET HOLD
+    //////////////////////////////////////////
+    
+    // Control Crystal Activation
+    ApplySpellFix({ 57804 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Destroy Door Seal
+    ApplySpellFix({ 58040 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE);
+    });
+
+    // Ichoron, Water Blast
+    ApplySpellFix({ 54237, 59520 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    //////////////////////////////////////////
+    ////////// AZJOL'NERUB
+    //////////////////////////////////////////
+
+    // Krik'thir - Mind Flay
+    ApplySpellFix({ 52586, 59367 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
+    });
+
+    //////////////////////////////////////////
+    ////////// HALLS OF STONE
+    //////////////////////////////////////////
+    
+    // Glare of the Tribunal
+    ApplySpellFix({ 50988, 59870 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Static Charge
+    ApplySpellFix({ 50835, 59847 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+    });
+
+    //////////////////////////////////////////
+    ////////// OBSIDIAN SANCTUM
+    //////////////////////////////////////////
+    
+    // Lava Strike damage
+    ApplySpellFix({ 57697 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Lava Strike trigger
+    ApplySpellFix({ 57578 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // Gift of Twilight Shadow/Fire
+    ApplySpellFix({ 57835, 58766 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
+    });
+
+    // Pyrobuffet
+    ApplySpellFix({ 57557 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 56911;
+    });
+
+    //////////////////////////////////////////
+    ////////// EYE OF ETERNITY
+    //////////////////////////////////////////
+    
+    // Arcane Barrage
+    ApplySpellFix({ 56397 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
+    });
+
+    ApplySpellFix({ 
+        55859, // Power Spark (ground +50% dmg aura) 
+        56438  // Arcane Overload (-50% dmg taken) - this is to prevent apply -> unapply -> apply ... dunno whether it's correct
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Vortex (Control Vehicle)
+    ApplySpellFix({ 56263 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Haste (Nexus Lord, increase run speed of the disk)
+    ApplySpellFix({ 57060 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_VEHICLE;
+    });
+
+    // Arcane Overload
+    ApplySpellFix({ 56430 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 56429;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
+    });
+
+    ApplySpellFix({ 56429 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Destroy Platform Event
+    ApplySpellFix({ 59099 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = 22;
+        spellInfo->Effects[EFFECT_1].TargetB = 15;
+        spellInfo->Effects[EFFECT_2].TargetA = 22;
+        spellInfo->Effects[EFFECT_2].TargetB = 15;
+    });
+
+    // Surge of Power (Phase 3) | Normal and Heroic
+    ApplySpellFix({ 57407, 60936 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = (spellInfo->Id == 60936 ? 3 : 1);
+        spellInfo->InterruptFlags = 0;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(28);
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Wyrmrest Drake - Life Burst
+    ApplySpellFix({ 57143 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(0);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_SRC_CASTER;
+        spellInfo->Effects[EFFECT_1].TargetB = TARGET_UNIT_SRC_AREA_ALLY;
+        spellInfo->Effects[EFFECT_1].PointsPerComboPoint = 2500;
+        spellInfo->Effects[EFFECT_1].BasePoints = 2499;
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(1);
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Alexstrasza - Gift
+    ApplySpellFix({ 61028 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Vortex (freeze anim)
+    ApplySpellFix({ 55883 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
+    //////////////////////////////////////////
+    ////////// ULDUAR
+    //////////////////////////////////////////
+    
+    // Flame Leviathan
+    // Hurl Pyrite
+    ApplySpellFix({ 62490 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Ulduar, Mimiron, Magnetic Core (summon)
+    ApplySpellFix({ 64444 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
+    });
+    
+    // Ulduar, Mimiron, bomb bot explosion
+    ApplySpellFix({ 63801 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].MiscValue = 17286;
+    });
+    
+    // Ulduar, Mimiron, Summon Flames Initial
+    ApplySpellFix({ 64563 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+    
+    // Ulduar, Mimiron, Flames (damage)
+    ApplySpellFix({ 64566 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    // Ulduar, Hodir, Starlight
+    ApplySpellFix({ 62807 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(16); // 1yd
+    });
+
+    // Ulduar, General Vezax, Mark of the Faceless
+    ApplySpellFix({ 63278 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+    });
+
+    // XT-002 DECONSTRUCTOR
+    ApplySpellFix({ 62834 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // ASSEMBLY OF IRON
+    // Supercharge
+    ApplySpellFix({ 61920 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Lightning Whirl
+    ApplySpellFix({ 61916 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 3;
+    });
+
+    ApplySpellFix({ 63482 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 8;
+    });
+
+    // KOLOGARN
+    // Stone Grip, remove absorb aura
+    ApplySpellFix({ 62056, 63985 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // AURIAYA
+    // Sentinel Blast
+    ApplySpellFix({ 64389, 64678 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Dispel = DISPEL_MAGIC;
+    });
+
+    // FREYA
+    // Potent Pheromones
+    ApplySpellFix({ 62619 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
+    });
+
+    // Healthy spore summon periodic
+    ApplySpellFix({ 62566 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Amplitude = 2000;
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
+    });
+
+    // Brightleaf Essence trigger
+    ApplySpellFix({ 62968 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0; // duplicate
+    });
+
+    // Potent Pheromones
+    ApplySpellFix({ 64321 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
+        spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
+    });
+
+    // THORIM
+    // charge obr stuff
+    ApplySpellFix({ 62186 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Amplitude = 5000; // Duration 5 secs, amplitude 8 secs...
+    });
+
+    // Charge Orb P2
+    ApplySpellFix({ 62976 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6);
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28);
+    });
+
+    // Sif's Blizzard
+    ApplySpellFix({ 62576, 62602 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
+    });
+
+    // YOGG-SARON
+    // Protective Gaze
+    ApplySpellFix({ 64175 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RecoveryTime = 25000;
+    });
+
+    // Shadow Beacon
+    ApplySpellFix({ 64465 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 64467; // why do they need two script effects :/ (this one has visual effect)
+    });
+
+    // Sanity
+    ApplySpellFix({ 63050 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+    });
+
+    // Shadow Nova
+    ApplySpellFix({ 62714, 65209 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // ALGALON
+    // Cosmic Smash (Algalon the Observer)
+    ApplySpellFix({ 62714, 65209 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
+    });
+
+    // Cosmic Smash (Algalon the Observer)
+    ApplySpellFix({ 62311, 64596 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);  // 50000yd
+    });
+
+    // Constellation Phase Effect
+    ApplySpellFix({ 65509 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // Black Hole
+    ApplySpellFix({ 62168, 65250, 62169 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
+    });
+
+    // TRASH
+    // Ground Slam
+    ApplySpellFix({ 62625 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+    });
+
+    //////////////////////////////////////////
+    ////////// ONYXIA'S LAIR
+    //////////////////////////////////////////
+
+    // Onyxia's Lair, Onyxia, Flame Breath (TriggerSpell = 0 and spamming errors in console)
+    ApplySpellFix({ 18435 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Onyxia's Lair, Onyxia, Create Onyxia Spawner
+    ApplySpellFix({ 17647 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(37);
+    });
+
+    ApplySpellFix({ 
+        17646, // Onyxia's Lair, Onyxia, Summon Onyxia Whelp
+        68968  // Onyxia's Lair, Onyxia, Summon Lair Guard
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(5);
+    });
+
+    // Onyxia's Lair, Onyxia, Eruption:
+    ApplySpellFix({ 17731, 69294 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(3);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(19); // 18yd instead of 13yd to make sure all cracks erupt
+    });
+
+    // Onyxia's Lair, Onyxia, Breath:
+    // TODO: fix it by IconId / SpellVisual
+    ApplySpellFix({ 
+        18576, 18578, 18579, 18580, 18581, 18582, 18583, 18609, 18611, 
+        18612, 18613, 18614, 18615, 18616, 18584, 18585, 18586, 18587, 
+        18588, 18589, 18590, 18591, 18592, 18593, 18594, 18595, 18564, 
+        18565, 18566, 18567, 18568, 18569, 18570, 18571, 18572, 18573, 
+        18574, 18575, 18596, 18597, 18598, 18599, 18600, 18601, 18602, 
+        18603, 18604, 18605, 18606, 18607, 18617, 18619, 18620, 18621, 
+        18622, 18623, 18624, 18625, 18626, 18627, 18628, 18618, 18351, 
+        18352, 18353, 18354, 18355, 18356, 18357, 18358, 18359, 18360, 
+        18361, 17086, 17087, 17088, 17089, 17090, 17091, 17092, 17093, 
+        17094, 17095, 17097, 22267, 22268, 21132, 21133, 21135, 21136, 
+        21137, 21138, 21139 
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(328); // 250ms
+        spellInfo->Effects[EFFECT_1].TargetA = 1;
+        
+        if (spellInfo->Effects[EFFECT_1].Effect)
+        {
+            spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+            spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
+            spellInfo->Effects[EFFECT_1].Amplitude = ((spellInfo->CastTimeEntry == sSpellCastTimesStore.LookupEntry(170)) ? 50 : 215);
+        }
+    });
+
+    //////////////////////////////////////////
+    ////////// THE NEXUS: OCULUS
+    //////////////////////////////////////////
+    
+    ApplySpellFix({ 
+        48760,  // Oculus, Teleport to Coldarra DND
+        49305   // Oculus, Teleport to Boss 1 DND
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(17);
+    });
+
+    // Oculus, Drake spell Stop Time
+    ApplySpellFix({ 49838 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+        spellInfo->ExcludeTargetAuraSpell = 51162; // exclude planar shift
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_150_YARDS);
+    });
+
+    // Oculus, Varos Cloudstrider, Energize Cores
+    ApplySpellFix({ 61407, 62136, 56251, 54069 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    //////////////////////////////////////////
+    ////////// HALLS OF LIGHTNING
+    //////////////////////////////////////////
+    
+    // Halls of Lightning, Arc Weld
+    ApplySpellFix({ 59086 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
+    });
+
+    // Halls of Lightning, Arcing Burn
+    ApplySpellFix({ 52671, 59834 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    //////////////////////////////////////////
+    ////////// TRIAL OF THE CHAMPION
+    //////////////////////////////////////////
+    
+    // Trial of the Champion, Death's Respite
+    ApplySpellFix({ 68306 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(25);
+    });
+
+    // Trial of the Champion, Eadric Achievement (The Faceroller)
+    ApplySpellFix({ 68197 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
+        spellInfo->Attributes |= SPELL_ATTR0_CASTABLE_WHILE_DEAD;
+    });
+
+    // Trial of the Champion, Earth Shield
+    ApplySpellFix({ 67530 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL; // will trigger 67537
+    });
+
+    // Trial of the Champion, Hammer of the Righteous
+    ApplySpellFix({ 66867 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
+    });
+
+    // Trial of the Champion, Summon Risen Jaeren/Arelas
+    ApplySpellFix({ 67705, 67715 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
+    });
+
+    // Trial of the Champion, Ghoul Explode
+    ApplySpellFix({ 67751 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+        spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
+    });
+
+    // Trial of the Champion, Desecration
+    ApplySpellFix({ 67778, 67877 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 68766;
+    });
+
+    //////////////////////////////////////////
+    ////////// TRIAL OF THE CRUSADER
+    //////////////////////////////////////////
+    
+    // Trial of the Crusader, Jaraxxus Intro spell
+    ApplySpellFix({ 67888 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
+        spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Trial of the Crusader, Lich King Intro spell
+    ApplySpellFix({ 68193 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
+    });
+
+    // Trial of the Crusader, Gormok, player vehicle spell, CUSTOM! (default jump to hand, not used)
+    ApplySpellFix({ 66342 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_SET_VEHICLE_ID;
+        spellInfo->Effects[EFFECT_0].MiscValue = 496;
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
+    // Trial of the Crusader, Gormok, Fire Bomb
+    ApplySpellFix({ 66313 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
+        spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    ApplySpellFix({ 66317 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
+        spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    ApplySpellFix({ 66318 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Speed = 14.0f;
+        spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
+        spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    ApplySpellFix({ 66320, 67472, 67473, 67475 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
+    });
+
+    // Trial of the Crusader, Acidmaw & Dreadscale, Emerge
+    ApplySpellFix({ 66947 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
+    });
+
+    // Trial of the Crusader, Jaraxxus, Curse of the Nether
+    ApplySpellFix({ 66211 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 66209; // exclude Touch of Jaraxxus
+    });
+
+    // Trial of the Crusader, Jaraxxus, Summon Volcano
+    ApplySpellFix({ 66258, 67901 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(85); // summon for 18 seconds, 15 not enough
+    });
+
+    // Trial of the Crusader, Jaraxxus, Spinning Pain Spike
+    ApplySpellFix({ 66281 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(26);
+    });
+
+    ApplySpellFix({ 66287 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_TAUNT;
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_NEARBY_ENTRY;
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_MOD_STUN;
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35); // 4 secs
+    });
+
+    // Trial of the Crusader, Jaraxxus, Fel Fireball
+    ApplySpellFix({ 66532, 66963, 66964, 66965 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+    });
+
+    // tempfix, make Nether Power not stealable
+    ApplySpellFix({ 66228, 67106, 67107, 67108 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
+    });
+
+    // Trial of the Crusader, Faction Champions, Druid - Tranquality
+    ApplySpellFix({ 66086, 67974, 67975, 67976 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
+    });
+
+    // Trial of the Crusader, Faction Champions, Shaman - Earth Shield
+    ApplySpellFix({ 66063 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 66064;
+    });
+
+    // Trial of the Crusader, Faction Champions, Priest - Mana Burn
+    ApplySpellFix({ 66100 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 5;
+        spellInfo->Effects[EFFECT_0].DieSides = 0;
+    });
+
+    ApplySpellFix({ 68026 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 8;
+        spellInfo->Effects[EFFECT_0].DieSides = 0;
+    });
+
+    ApplySpellFix({ 68027 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 6;
+        spellInfo->Effects[EFFECT_0].DieSides = 0;
+    });
+
+    ApplySpellFix({ 68028 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 10;
+        spellInfo->Effects[EFFECT_0].DieSides = 0;
+    });
+
+    // Trial of the Crusader, Twin Valkyr, Touch of Light/Darkness, Light/Dark Surge
+    // light 0
+    ApplySpellFix({ 65950 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 65686;
+    });
+
+    // light surge 0
+    ApplySpellFix({ 65767 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 65686;
+    });
+
+    // light 1
+    ApplySpellFix({ 67296 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67222;
+    });
+
+    // light surge 1
+    ApplySpellFix({ 67274 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67222;
+    });
+
+    // light 2
+    ApplySpellFix({ 67297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67223;
+    });
+
+    // light surge 2
+    ApplySpellFix({ 67275 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67223;
+    });
+
+    // light 3
+    ApplySpellFix({ 67298 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67224;
+    });
+
+    // light surge 3
+    ApplySpellFix({ 67276 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67224;
+    });
+
+    // Dark 0
+    ApplySpellFix({ 66001 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 65684;
+    });
+
+    // Dark surge 0
+    ApplySpellFix({ 65769 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 65684;
+    });
+
+    // Dark 1
+    ApplySpellFix({ 67281 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67176;
+    });
+
+    // Dark surge 1
+    ApplySpellFix({ 67265 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67176;
+    });
+
+    // Dark 2
+    ApplySpellFix({ 67282 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67177;
+    });
+
+    // Dark surge 2
+    ApplySpellFix({ 67266 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67177;
+    });
+
+    // Dark 3
+    ApplySpellFix({ 67283 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+        spellInfo->ExcludeTargetAuraSpell = 67178;
+    });
+
+    // Dark surge 3
+    ApplySpellFix({ 67267 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 67178;
+    });
+
+    // Trial of the Crusader, Twin Valkyr, Twin's Pact
+    ApplySpellFix({ 65875, 67303, 67304, 67305, 65876, 67306, 67307, 67308 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Trial of the Crusader, Anub'arak, Emerge
+    ApplySpellFix({ 65982 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
+    });
+
+    // Trial of the Crusader, Anub'arak, Penetrating Cold
+    ApplySpellFix({ 66013, 67700, 68509, 68510 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
+    });
+
+    // Trial of the Crusader, Anub'arak, Shadow Strike
+    ApplySpellFix({ 66134 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+    });
+
+    // Trial of the Crusader, Anub'arak, Pursuing Spikes
+    ApplySpellFix({ 65920, 65922, 65923 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
+    });
+
+    // Trial of the Crusader, Anub'arak, Summon Scarab
+    ApplySpellFix({ 66339 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35);
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Trial of the Crusader, Anub'arak, Achievements: The Traitor King
+    ApplySpellFix({ 
+        68186, // Anub'arak Scarab Achievement 10
+        68515  // Anub'arak Scarab Achievement 25
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
+        spellInfo->Attributes |= SPELL_ATTR0_CASTABLE_WHILE_DEAD;
+    });
+
+    // Trial of the Crusader, Anub'arak, Spider Frenzy
+    ApplySpellFix({ 66129 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    //////////////////////////////////////////
+    ////////// THE FORGE OF SOULS
+    //////////////////////////////////////////
+
+    // Soul Sickness
+    ApplySpellFix({ 69131 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
+        spellInfo->Effects[EFFECT_0].Amplitude = 8000;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 69133;
+    });
+
+    // Phantom Blast
+    ApplySpellFix({ 68982, 70322 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
+    });
+
+    //////////////////////////////////////////
+    ////////// PIT OF SARON
+    //////////////////////////////////////////
+
+    // Empowered Blizzard
+    ApplySpellFix({ 70131 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Ice Lance Volley
+    ApplySpellFix({ 70464 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(25);
+    });
+
+    ApplySpellFix({ 
+        70513, // Multi-Shot 
+        59514  // Shriek of the Highborne
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Icicle
+    ApplySpellFix({ 69428, 69426 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->InterruptFlags = 0;
+        spellInfo->AuraInterruptFlags = 0;
+        spellInfo->ChannelInterruptFlags = 0;
+    });
+
+    ApplySpellFix({ 
+        70525, // Jaina's Call
+        70639  // Call of Sylvanas
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_SRC_CASTER;
+        spellInfo->Effects[EFFECT_2].TargetB = TARGET_UNIT_SRC_AREA_ENTRY;
+        spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(30); // 500yd
+    });
+
+    // Frost Nova
+    ApplySpellFix({ 68198 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+    });
+
+    // Blight
+    ApplySpellFix({ 69604, 70286 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 1;
+        spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
+    });
+
+    // Chilling Wave
+    ApplySpellFix({ 68778, 70333 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Permafrost
+    ApplySpellFix({ 68786, 70336 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
+        spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_DUMMY;
+    });
+
+    // Pursuit
+    ApplySpellFix({ 68987 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_TARGET_ANY;
+        spellInfo->Effects[EFFECT_1].TargetB = 0;
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
+        spellInfo->Effects[EFFECT_2].TargetB = 0;
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    ApplySpellFix({ 69029, 70850 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Explosive Barrage
+    ApplySpellFix({ 69263 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_STUN;
+    });
+
+    // Overlord's Brand
+    ApplySpellFix({ 69172 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcFlags = DONE_HIT_PROC_FLAG_MASK & ~PROC_FLAG_DONE_PERIODIC;
+        spellInfo->ProcChance = 100;
+    });
+
+    // Icy Blast
+    ApplySpellFix({ 69232 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TriggerSpell = 69238;
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    ApplySpellFix({ 69233, 69646 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    ApplySpellFix({ 69238, 69628 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Hoarfrost
+    ApplySpellFix({ 69246, 69245, 69645 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Devour Humanoid
+    ApplySpellFix({ 69503 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ChannelInterruptFlags |= 0;
+        spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
+    });
+
+    //////////////////////////////////////////
+    ////////// HALLS OF REFLECTION
+    //////////////////////////////////////////
+    
+    // Falric: Defiling Horror
+    ApplySpellFix({ 72435, 72452 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
+    });
+
+    // Frostsworn General - Throw Shield
+    ApplySpellFix({ 69222, 73076 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ENEMY;
+    });
+
+    // Halls of Reflection Clone
+    ApplySpellFix({ 69828 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Summon Ice Wall
+    ApplySpellFix({ 69768 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    ApplySpellFix({ 69767 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    // Essence of the Captured
+    ApplySpellFix({ 73035, 70719 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
+    });
+
+    // Achievement Check
+    ApplySpellFix({ 72830 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
+    });
+
+    //////////////////////////////////////////
+    ////////// ICECROWN CITADEL
+    //////////////////////////////////////////
+
+    ApplySpellFix({ 
+        70781, // Light's Hammer Teleport
+        70856, // Oratory of the Damned Teleport
+        70857, // Rampart of Skulls Teleport
+        70858, // Deathbringer's Rise Teleport
+        70859, // Upper Spire Teleport
+        70860, // Frozen Throne Teleport
+        70861  // Sindragosa's Lair Teleport
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB); // this target is for SPELL_EFFECT_TELEPORT_UNITS
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
+    });
+
+    ApplySpellFix({ 
+        70960, // Bone Flurry
+        71258, // Adrenaline Rush (Ymirjar Battle-Maiden)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_2;
+    });
+
+    // Saber Lash (Lord Marrowgar)
+    ApplySpellFix({ 69055, 70814 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
+    });
+
+    // Impaled (Lord Marrowgar)
+    ApplySpellFix({ 69065 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0; // remove stun so Dispersion can be used
+    });
+
+    // Cold Flame (Lord Marrowgar)
+    ApplySpellFix({ 72701, 72702, 72703, 72704 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 secs instead of 12, need him for longer, but will stop his actions after 12 secs
+    });
+
+    // Coldflame (Lord Marrowgar)
+    ApplySpellFix({ 69138 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0;
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_DEST_DEST;
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 secs instead of 12, need him for longer, but will stop his actions after 12 secs
+    });
+
+    // Coldflame (Lord Marrowgar)
+    ApplySpellFix({ 69146, 70823, 70824, 70825 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(15); // 3yd instead of 5yd
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    // Dark Martyrdom (Lady Deathwhisper)
+    ApplySpellFix({ 70897 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
+    });
+
+    ApplySpellFix({ 
+        69075, // Bone Storm (Lord Marrowgar)
+        70834, // Bone Storm (Lord Marrowgar)
+        70835, // Bone Storm (Lord Marrowgar)
+        70836, // Bone Storm (Lord Marrowgar)
+        72378, // Blood Nova (Deathbringer Saurfang)
+        73058, // Blood Nova (Deathbringer Saurfang)
+        72769, // Scent of Blood (Deathbringer Saurfang)
+        72385, // Boiling Blood (Deathbringer Saurfang)
+        72441, // Boiling Blood (Deathbringer Saurfang)
+        72442, // Boiling Blood (Deathbringer Saurfang)
+        72443, // Boiling Blood (Deathbringer Saurfang)
+        71160, // Plague Stench (Stinky)
+        71161, // Plague Stench (Stinky)
+        71123, // Decimate (Stinky & Precious)
+        71464  // Divine Surge (Sister Svalna) 
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12);   // 100yd
+    });
+
+    // Shadow's Fate
+    ApplySpellFix({ 71169 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    // Lock Players and Tap Chest
+    ApplySpellFix({ 72347 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 &= ~SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // Award Reputation - Boss Kill
+    ApplySpellFix({ 73843, 73844, 73845, 73846 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);
+    });
+
+    // Death Plague (Rotting Frost Giant)
+    ApplySpellFix({ 72864 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 0;
+    });
+
+    // Gunship Battle, spell Below Zero
+    ApplySpellFix({ 72864 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Resistant Skin (Deathbringer Saurfang adds)
+    ApplySpellFix({ 72723 }, [](SpellInfo* spellInfo)
+    {
+        // this spell initially granted Shadow damage immunity, however it was removed but the data was left in client
+        spellInfo->Effects[EFFECT_2].Effect = 0;
+    });
+
+    // Mark of the Fallen Champion (Deathbringer Saurfang) 
+    // Patch 3.3.2 (2010-01-02): Deathbringer Saurfang will no longer gain blood power from Mark of the Fallen Champion.
+    // Xinef: prevented in script, effect needed for Prayer of Mending
+    ApplySpellFix({ 72255, 72444, 72445, 72446 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
+    });
+
+    // Coldflame Jets (Traps after Saurfang)
+    ApplySpellFix({ 70460 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);  // 10 seconds
+    });
+
+    ApplySpellFix({ 
+        70461, // Coldflame Jets (Traps after Saurfang)
+        71289  // Dominate Mind (Lady Deathwhisper)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Severed Essence (Val'kyr Herald)
+    ApplySpellFix({ 71906, 71942 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    ApplySpellFix({ 
+        71159, // Awaken Plagued Zombies (Precious)
+        71302  // Awaken Ymirjar Fallen (Ymirjar Deathbringer)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
+    });
+
+    // Blood Prince Council, Invocation of Blood
+    ApplySpellFix({ 70981, 70982, 70952 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = 0; // clear share health aura
+    });
+
+    // Ymirjar Frostbinder, Frozen Orb
+    ApplySpellFix({ 71274 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
+    });
+
+    // Ooze Flood (Rotface)
+    ApplySpellFix({ 69783, 69797, 69799, 69802 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_CANT_TARGET_SELF;
+    });
+
+    // Volatile Ooze Beam Protection
+    ApplySpellFix({ 70530 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA; // blizzard typo, 65 instead of 6, aura itself is defined (dummy)
+    });
+
+    // Professor Putricide, Gaseous Bloat (Orange Ooze Channel) -- copied attributes from Green Ooze Channel
+    ApplySpellFix({ 70672, 72455, 72832, 72833 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    ApplySpellFix({ 
+        71412, // Green Ooze Summon (Professor Putricide)
+        71415  // Orange Ooze Summon (Professor Putricide)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+    });
+
+    ApplySpellFix({ 
+        71621,
+        72850,
+        72851,
+        72852, // Create Concoction (Professor Putricide)
+        71893,
+        73120,
+        73121,
+        73122  // Guzzle Potions (Professor Putricide)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(15); // 4 sec
+    });
+
+    // Mutated Plague (Professor Putricide)
+    ApplySpellFix({ 72454, 72464, 72506, 72507 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Unbound Plague (Professor Putricide) (needs target selection script)
+    ApplySpellFix({ 70911, 72854, 72855, 72856 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+    });
+
+    // Mutated Transformation (Professor Putricide)
+    ApplySpellFix({ 70402, 72511, 72512, 72513 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
+    });
+
+    // Empowered Flare (Blood Prince Council)
+    ApplySpellFix({ 71708, 72785, 72786, 72787 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+    
+    ApplySpellFix({ 
+        71518, // Unholy Infusion Quest Credit (Professor Putricide)
+        72934, // Blood Infusion Quest Credit (Blood-Queen Lana'thel)
+        72289  // Frost Infusion Quest Credit (Sindragosa)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // another missing radius
+    });
+
+    // Swarming Shadows
+    ApplySpellFix({ 71266, 72890 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AreaGroupId = 0; // originally, these require area 4522, which is... outside of Icecrown Citadel
+    });
+
+    ApplySpellFix({ 
+        71301, // Summon Dream Portal (Valithria Dreamwalker)
+        71977  // Summon Nightmare Portal (Valithria Dreamwalker)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Column of Frost (visual marker)
+    ApplySpellFix({ 70715 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(32); // 6 seconds (missing)
+    });
+
+    // Mana Void (periodic aura)
+    ApplySpellFix({ 71085 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 seconds (missing)
+    });
+
+    // Summon Suppressor (needs target selection script)
+    ApplySpellFix({ 70936 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Corruption
+    ApplySpellFix({ 70602 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+    });
+
+    ApplySpellFix({ 
+        72706, // Achievement Check (Valithria Dreamwalker)
+        71357  // Achievement Check (Valithria Dreamwalker)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+    });
+
+    // Sindragosa's Fury
+    ApplySpellFix({ 70598 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Tail Smash (Sindragosa)
+    ApplySpellFix({ 71077 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER_BACK);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
+        spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER_BACK);
+        spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
+    });
+
+    // Frost Bomb
+    ApplySpellFix({ 69846 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0.0f;    // This spell's summon happens instantly
+    });
+
+    // Mystic Buffet (Sindragosa) - remove obsolete spell effect with no targets
+    ApplySpellFix({ 
+        70127,
+        72528,
+        72529,
+        72530
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Sindragosa, Frost Aura
+    ApplySpellFix({ 70084, 71050, 71051, 71052 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+    });
+
+    // Ice Lock
+    ApplySpellFix({ 71614 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Mechanic = MECHANIC_STUN;
+    });
+
+    // Lich King, Infest
+    ApplySpellFix({ 70541, 73779, 73780, 73781 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // Lich King, Necrotic Plague
+    ApplySpellFix({ 70337, 73912, 73913, 73914, 70338, 73785, 73786, 73787 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Ice Pulse
+    ApplySpellFix({ 69099, 73776, 73777, 73778 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    // Fury of Frostmourne
+    ApplySpellFix({ 72350 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    ApplySpellFix({ 
+        72351, // Fury of Frostmourne
+        72431, // Jump (removes Fury of Frostmourne debuff)
+        72429, // Mass Resurrection
+        73159  // Play Movie 
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Raise Dead
+    ApplySpellFix({ 72376 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->MaxAffectedTargets = 4;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Jump
+    ApplySpellFix({ 71809 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(5); // 40yd
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // 10yd
+        spellInfo->Effects[EFFECT_0].MiscValue = 190;
+    });
+
+    // Broken Frostmourne
+    ApplySpellFix({ 72405 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+    });
+
+    // Summon Shadow Trap
+    ApplySpellFix({ 73540 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(3);  // 60 seconds
+    });
+
+    // Shadow Trap (visual)
+    ApplySpellFix({ 73530 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28); // 5 seconds
+    });
+
+    // Shadow Trap
+    ApplySpellFix({ 73529 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);   // 10yd
+    });
+
+    // Raging Spirit Visual
+    ApplySpellFix({ 69198 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);             // 50000yd
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
+    });
+
+    // Defile
+    ApplySpellFix({ 72762 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(559); // 53 seconds
+        spellInfo->ExcludeCasterAuraSpell = 0;
+        spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+        spellInfo->AttributesEx6 |= (SPELL_ATTR6_CAN_TARGET_INVISIBLE | SPELL_ATTR6_CAN_TARGET_UNTARGETABLE);
+    });
+
+    // Defile
+    ApplySpellFix({ 72743 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(22); // 45 seconds
+    });
+
+    // Defile
+    ApplySpellFix({ 72754, 73708, 73709, 73710 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+    });
+
+    // Val'kyr Target Search
+    ApplySpellFix({ 69030 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+        spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+    });
+
+    // Harvest Souls
+    ApplySpellFix({ 73654, 74295, 74296, 74297 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+        spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Restore Soul
+    ApplySpellFix({ 72595, 73650 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+    });
+
+    // Kill Frostmourne Players
+    ApplySpellFix({ 75127 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Harvest Soul
+    ApplySpellFix({ 73655 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
+    });
+
+    // Destroy Soul
+    ApplySpellFix({ 74086 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+    });
+
+    // Summon Spirit Bomb
+    ApplySpellFix({ 74302, 74342 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+        spellInfo->MaxAffectedTargets = 1;
+    });
+
+    // Summon Spirit Bomb
+    ApplySpellFix({ 74341, 74343 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
+        spellInfo->MaxAffectedTargets = 3;
+    });
+
+    // Summon Spirit Bomb
+    ApplySpellFix({ 73579 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS);   // 25yd
+    });
+
+    // Trigger Vile Spirit (Inside, Heroic)
+    ApplySpellFix({ 73582 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
+    });
+
+    // Scale Aura (used during Dominate Mind from Lady Deathwhisper)
+    ApplySpellFix({ 73261 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
+    // Leap to a Random Location
+    ApplySpellFix({ 70485 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
+        spellInfo->Effects[EFFECT_0].MiscValue = 100;
+    });
+
+    // Empowered Blood
+    ApplySpellFix({ 70227, 70232 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AreaGroupId = 2452; // Whole icc instead of Crimson Halls only, remove when area calculation is fixed
+    });
+
+    //////////////////////////////////////////
+    ////////// RUBY SANCTUN
+    //////////////////////////////////////////
+    
+    // Repelling Wave
+    ApplySpellFix({ 74509 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
+    });
+
+    // Rallying Shout
+    ApplySpellFix({ 75414 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
+    });
+
+    // Barrier Channel
+    ApplySpellFix({ 76221 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_TURNING | AURA_INTERRUPT_FLAG_MOVE);
+        spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_NEARBY_ENTRY;
+    });
+
+    // Intimidating Roar
+    ApplySpellFix({ 74384 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
+    });
+
+    ApplySpellFix({ 
+        74562, // Fiery Combustion
+        74792  // Soul Consumption
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
+    });
+
+    // Combustion
+    ApplySpellFix({ 75883, 75884 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
+    });
+
+    // Consumption
+    ApplySpellFix({ 75875, 75876 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
+        spellInfo->Effects[EFFECT_0].Mechanic = MECHANIC_NONE;
+        spellInfo->Effects[EFFECT_1].Mechanic = MECHANIC_SNARE;
+    });
+
+    // Soul Consumption
+    ApplySpellFix({ 74799 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_12_YARDS);
+    });
+
+    // Twilight Cutter
+    ApplySpellFix({ 74769, 77844, 77845, 77846 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
+    });
+
+    // Twilight Mending
+    ApplySpellFix({ 75509 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
+        spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
+    });
+
+    // Meteor Strike
+    ApplySpellFix({ 74637 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Speed = 0;
+    });
+
+    // Blazing Aura
+    ApplySpellFix({ 75885, 75886 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    ApplySpellFix({ 
+        75952, // Meteor Strike
+        74629  // Combustion Periodic
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
+    });
+
+    // ///////////////////////////////////////////
+    // ////////////////QUESTS/////////////////////
+    // ///////////////////////////////////////////
+
+    // Going Bearback (12851)
+    ApplySpellFix({ 54897 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
+        spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_DEST_AREA_ENTRY;
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
+    });
+
+    // Still At It (12644)
+    ApplySpellFix({ 51931, 51932, 51933 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(38);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
+    });
+
+    // Rallying the Troops (12070)
+    ApplySpellFix({ 47394 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ExcludeTargetAuraSpell = 47394;
+    });
+
+    // A Tangled Skein (12555)
+    ApplySpellFix({ 51165, 51173 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
+    });
+
+    // A Cloudlet of Classy Cologne (24635)
+    ApplySpellFix({ 
+        69563, // A Cloudlet of Classy Cologne (24635)
+        69445, // A Perfect Puff of Perfume (24629)
+        69489  // Bonbon Blitz (24636)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
+    });
+
+    // Control (9595)
+    ApplySpellFix({ 30790 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].MiscValue = 0;
+    });
+
+    // Reclusive Runemaster (12150)
+    ApplySpellFix({ 48028 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
+        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
+    });
+
+    // Mastery of
+    ApplySpellFix({ 65147 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->CategoryEntry = sSpellCategoryStore.LookupEntry(1244);
+        spellInfo->CategoryRecoveryTime = 1500;
+    });
+
+    // Weakness to Lightning (11896)
+    ApplySpellFix({ 46432 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 &= ~SPELL_ATTR3_DEATH_PERSISTENT;
+    });
+
+    // Wrangle Some Aether Rays! (11065)
+    ApplySpellFix({ 40856 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(27); // 3000ms
+    });
+
+    // The Black Knight's Orders (13663)
+    ApplySpellFix({ 63163 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 52390;
+    });
+
+    // The Warp Rifts (10278)
+    ApplySpellFix({ 34888 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(5); // 300 secs
+    });
+
+    // The Smallest Creatures (10720)
+    ApplySpellFix({ 38544 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValueB = 427;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
+        spellInfo->Effects[EFFECT_1].Effect = 0;
+    });
+
+    // Ridding the red rocket
+    ApplySpellFix({ 49177 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 1; // corrects seat id (points - 1 = seatId)
+    });
+
+    // The Iron Colossus (13007)
+    ApplySpellFix({ 56513, 56524 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->RecoveryTime = (spellInfo->Id == 56524 ? 6000 : 2000);
+    });
+
+    // Kaw the Mammoth Destroyer (11879)
+    ApplySpellFix({ 46260 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
+    });
+
+    // That's Abominable (13264, 13276, 13288, 13289)
+    ApplySpellFix({ 59565 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValueB = 1721; // controlable guardian
+    });
+
+    // Investigate the Blue Recluse (1920)
+    // Investigate the Alchemist Shop (1960)
+    ApplySpellFix({ 9095 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13);
+    });
+
+    // Dragonmaw Race: All parts
+    ApplySpellFix({ 40890 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Trope's Slime Cannon
+    ApplySpellFix({ 40909 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Corlok's Skull Barrage
+    ApplySpellFix({ 40894 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 40900;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Ichman's Blazing Fireball
+    ApplySpellFix({ 40928 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 40929;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Mulverick's Great Balls of Lightning
+    ApplySpellFix({ 40930 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 40931;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Sky Shatter
+    ApplySpellFix({ 40945 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
+        spellInfo->Effects[EFFECT_0].TriggerSpell = 41064;
+        spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
+    });
+
+    // Gauging the Resonant Frequency (10594)
+    ApplySpellFix({ 37390 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].MiscValueB = 181;
+    });
+
+    // Where in the World is Hemet Nesingwary? (12521)
+    ApplySpellFix({ 50860 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 50860;
+    });
+
+    ApplySpellFix({ 50861 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 0;
+    });
+
+    // Krolmir, Hammer of Storms (13010)
+    ApplySpellFix({ 56606, 56541 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 1;
+    });
+
+    // Blightbeasts be Damned! (12072)
+    ApplySpellFix({ 47424 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags &= ~AURA_INTERRUPT_FLAG_NOT_ABOVEWATER;
+    });
+
+    // Leading the Charge (13380), All Infra-Green bomber quests
+    ApplySpellFix({ 59059 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
+    });
+
+    // Dark Horizon (12664), Reunited (12663)
+    ApplySpellFix({ 52190 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].BasePoints = 52391 - 1;
+    });
     
     for (auto spellInfo : mSpellInfoMap)
     {
@@ -4798,1800 +7063,6 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         switch (spellInfo->Id)
         {
-            // Blackfathom Deeps
-            // Shadowstalker Stealth
-            case 5916:
-                spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
-                break;
-
-            // Maraudon
-            // Sneak
-            case 22766:
-                spellInfo->Effects[EFFECT_0].RealPointsPerLevel = 5.0f;
-                break;
-
-
-            //////////////////////////////////////////
-            ////////// TBC Instances
-            //////////////////////////////////////////
-
-            // Shadow Labirynth
-            // Murmur's Touch
-            case 38794:
-            case 33711:
-                spellInfo->MaxAffectedTargets = 1;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 33760;
-                break;
-
-            // The Arcatraz
-            // Negaton Field
-            case 36729: // Normal
-            case 38834: // Heroic
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Curse of the Doomsayer NORMAL
-            case 36173:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 36174; // Currently triggers heroic version...
-                break;
-
-            // The Botanica
-            // Crystal Channel
-            case 34156:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(35); // 35yd;
-                spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
-                break;
-
-            // Magtheridon's Lair
-            // Debris
-            case 36449:
-                spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
-                break;
-            // Soul Channel
-            case 30531:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Debris Visual
-            case 30632:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_ALLY);
-                break;
-
-            // Sunwell Plateu
-            // Activate Sunblade Protecto
-            case 46475:
-            case 46476:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(14); // 60yd
-                break;
-            // Break Ice
-            case 46638:
-                spellInfo->AttributesEx3 &= ~SPELL_ATTR3_ONLY_TARGET_PLAYERS; // Obvious fail, it targets gameobject...
-                break;
-            // Sinister Reflection Clone
-            case 45785:
-                spellInfo->Speed = 0.0f;
-                break;
-            // Armageddon
-            case 45909:
-                spellInfo->Speed = 8.0f;
-                break;
-
-            // Black Temple
-            // Spell Absorption
-            case 41034:
-                spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_SCHOOL_ABSORB;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
-                spellInfo->Effects[EFFECT_2].MiscValue = SPELL_SCHOOL_MASK_MAGIC;
-                break;
-            // Shared Bonds
-            case 41363:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
-                break;
-            // Deadly Poison
-            case 41485:
-            // Envenom
-            case 41487:
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
-                break;
-            // Parasitic Shadowfiend
-            case 41914:
-                spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Teleport Maiev
-            case 41221:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
-                break;
-
-            // Serpentshrine Cavern
-            // Watery Grave Explosion
-            case 37852:
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
-                break;
-
-            // Karazhan
-            // Amplify Damage
-            case 39095:
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-
-            // Magisters' Terrace
-            // Energy Feedback
-            case 44335:
-                spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
-                break;
-
-            /*
-                Raid: Battle for Mount Hyjal
-                Boss: Archimonde
-            */
-            case 31984: // Spell doesn't need to ignore invulnerabilities
-            case 35354:
-                spellInfo->Attributes = SPELL_ATTR0_ABILITY;
-                break;
-            case 32111: // We only need the animation, no damage
-                spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(0);
-                break;
-
-            //////////////////////////////////////////
-            ////////// Vault of Archavon (VOA)
-            //////////////////////////////////////////
-            // Flame Breath, catapult spell
-            case 50989:
-                spellInfo->Attributes &= ~SPELL_ATTR0_LEVEL_DAMAGE_CALCULATION;
-                break;
-            // Koralon, Flaming Cinder missing radius index
-            case 66690:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); //100yd
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-
-            //////////////////////////////////////////
-            ////////// Naxxramas
-            //////////////////////////////////////////
-            // Acid Volley
-            case 54714:
-            case 29325:
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-            // Summon Plagued Warrior
-            case 29237:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-                spellInfo->Effects[EFFECT_1].Effect = spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            // Icebolt
-            case 28526:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            // Infected Wound
-            case 29306:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Hopeless
-            case 29125:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                break;
-            // Jagged Knife
-            case 55550:
-                spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
-                break;
-
-            //////////////////////////////////////////
-            ////////// Gundrak
-            //////////////////////////////////////////
-            // Moorabi - Transformation
-            case 55098:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                break;
-            case 55521: // Poisoned Spear (Normal)
-            case 58967: // Poisoned Spear (Heroic)
-            case 55348: // Throw (Normal)
-            case 58966: // Throw (Heroic)
-                spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
-                break;
-
-            //////////////////////////////////////////
-            ////////// The Nexus: Nexus
-            //////////////////////////////////////////
-            // Charged Chaotic rift aura, trigger
-            case 47737:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(37); // 50yd
-                break;
-
-            //////////////////////////////////////////
-            ////////// AHN'KAHET: THE OLD KINGDOM
-            //////////////////////////////////////////
-            // Vanish
-            case 55964:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-
-            //////////////////////////////////////////
-            ////////// DRAK'THARON KEEP
-            //////////////////////////////////////////
-            // Trollgore - Summon Drakkari Invader
-            case 49456:
-            case 49457:
-            case 49458:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
-                break;
-
-            //////////////////////////////////////////
-            ////////// UTGARDE PINNACLE
-            //////////////////////////////////////////
-            // Paralyse
-            case 48278:
-            // Awaken subboss
-            case 47669:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Flame Breath
-            case 47592:
-                spellInfo->Effects[EFFECT_0].Amplitude = 200;
-                break;
-
-            //////////////////////////////////////////
-            ////////// UTGARDE KEEP
-            //////////////////////////////////////////
-            // Skarvald, Charge
-            case 43651:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13); // 0-50000yd
-                break;
-            // Ingvar the Plunderer, Woe Strike
-            case 42730:
-                spellInfo->Effects[EFFECT_1].TriggerSpell = 42739;
-                break;
-            case 59735:
-                spellInfo->Effects[EFFECT_1].TriggerSpell = 59736;
-                break;
-            // Ingvar the Plunderer, Ingvar transform
-            case 42796:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_DEATH_PERSISTENT;
-                break;
-            case 42772: // Hurl Dagger (Normal)
-            case 59685: // Hurl Dagger (Heroic)
-                spellInfo->Attributes |= SPELL_ATTR0_REQ_AMMO;
-                break;
-
-            //////////////////////////////////////////
-            ////////// VIOLET HOLD
-            //////////////////////////////////////////
-            // Control Crystal Activation
-            case 57804:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Destroy Door Seal
-            case 58040:
-                spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_HITBYSPELL | AURA_INTERRUPT_FLAG_TAKE_DAMAGE);
-                break;
-            // Ichoron, Water Blast
-            case 54237:
-            case 59520:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-
-            //////////////////////////////////////////
-            ////////// AZJOL'NERUB
-            //////////////////////////////////////////
-
-            // Krik'thir - Mind Flay
-            case 52586:
-            case 59367:
-                spellInfo->ChannelInterruptFlags |= AURA_INTERRUPT_FLAG_MOVE;
-                break;
-
-            //////////////////////////////////////////
-            ////////// HALLS OF STONE
-            //////////////////////////////////////////
-            // Glare of the Tribunal
-            case 50988:
-            case 59870:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Static Charge
-            case 50835:
-            case 59847:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                break;
-
-            //////////////////////////////////////////
-            ////////// OBSIDIAN SANCTUM
-            //////////////////////////////////////////
-            // Lava Strike damage
-            case 57697:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            // Lava Strike trigger
-            case 57578:
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-            // Gift of Twilight Shadow/Fire
-            case 57835:
-            case 58766:
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_1;
-                break;
-            // Pyrobuffet
-            case 57557:
-                spellInfo->ExcludeTargetAuraSpell = 56911;
-                break;
-
-            //////////////////////////////////////////
-            ////////// EYE OF ETERNITY
-            //////////////////////////////////////////
-            // Arcane Barrage
-            case 56397:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Power Spark (ground +50% dmg aura)
-            case 55849:
-            // Arcane Overload (-50% dmg taken) - this is to prevent apply -> unapply -> apply ... dunno whether it's correct
-            case 56438:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Vortex (Control Vehicle)
-            case 56263:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            // Haste (Nexus Lord, increase run speed of the disk)
-            case 57060:
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_VEHICLE;
-                break;
-            // Arcane Overload
-            case 56430:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 56429;
-                [[fallthrough]];
-            case 56429:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Destroy Platform Event
-            case 59099:
-                spellInfo->Effects[EFFECT_1].TargetA = 22;
-                spellInfo->Effects[EFFECT_1].TargetB = 15;
-                spellInfo->Effects[EFFECT_2].TargetA = 22;
-                spellInfo->Effects[EFFECT_2].TargetB = 15;
-                break;
-            // Surge of Power (Phase 3)
-            case 57407: // N
-            case 60936: // H
-                spellInfo->MaxAffectedTargets = (i == 60936 ? 3 : 1);
-                spellInfo->InterruptFlags = 0;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(28);
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // Wyrmrest Drake - Life Burst
-            case 57143:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(0);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_SRC_CASTER;
-                spellInfo->Effects[EFFECT_1].TargetB = TARGET_UNIT_SRC_AREA_ALLY;
-                spellInfo->Effects[EFFECT_1].PointsPerComboPoint = 2500;
-                spellInfo->Effects[EFFECT_1].BasePoints = 2499;
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(1);
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            //Alexstrasza - Gift
-            case 61028:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            // Vortex (freeze anim)
-            case 55883:
-                spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
-                break;
-
-            //////////////////////////////////////////
-            ////////// ULDUAR
-            //////////////////////////////////////////
-            // Flame Leviathan
-            // Hurl Pyrite
-            case 62490:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-
-            // Ulduar, Mimiron, Magnetic Core (summon)
-            case 64444:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
-                break;
-            // Ulduar, Mimiron, bomb bot explosion
-            case 63801:
-                spellInfo->Effects[EFFECT_1].MiscValue = 17286;
-                break;
-            // Ulduar, Mimiron, Summon Flames Initial
-            case 64563:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Ulduar, Mimiron, Flames (damage)
-            case 64566:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-
-            // Ulduar, Hodir, Starlight
-            case 62807:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(16); // 1yd
-                break;
-
-            // Ulduar, General Vezax, Mark of the Faceless
-            case 63278:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                break;
-
-            // XT-002 DECONSTRUCTOR
-            case 62834: // Boom (XT-002)
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-
-            // ASSEMBLY OF IRON
-            // Supercharge
-            case 61920:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            // Lightning Whirl
-            case 61916:
-                spellInfo->MaxAffectedTargets = 3;
-                break;
-            case 63482:
-                spellInfo->MaxAffectedTargets = 8;
-                break;
-
-            // KOLOGARN
-            // Stone Grip, remove absorb aura
-            case 62056:
-            case 63985:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-
-            // AURIAYA
-            // Sentinel Blast
-            case 64389:
-            case 64678:
-                spellInfo->Dispel = DISPEL_MAGIC;
-                break;
-
-            // FREYA
-            // Potent Pheromones
-            case 62619:
-                spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
-                break;
-            // Healthy spore summon periodic
-            case 62566:
-                spellInfo->Effects[EFFECT_0].Amplitude = 2000;
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
-                break;
-            // Brightleaf Essence trigger
-            case 62968:
-                spellInfo->Effects[EFFECT_1].Effect = 0; // duplicate
-                break;
-            // Potent Pheromones
-            case 64321:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_ONLY_TARGET_PLAYERS;
-                spellInfo->AttributesEx |= SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY;
-                break;
-
-            // THORIM
-            // charge obr stuff
-            case 62186:
-                spellInfo->Effects[EFFECT_0].Amplitude = 5000; // Duration 5 secs, amplitude 8 secs...
-                break;
-            // Charge Orb P2
-            case 62976:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6);
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28);
-                break;
-            // Sif's Blizzard
-            case 62576:
-            case 62602:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(14); // 8yd
-                break;
-
-            // YOGG-SARON
-            // Protective Gaze
-            case 64175:
-                spellInfo->RecoveryTime = 25000;
-                break;
-            // Shadow Beacon
-            case 64465:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 64467; // why do they need two script effects :/ (this one has visual effect)
-                break;
-            // Sanity
-            case 63050:
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
-                break;
-            // Shadow Nova
-            case 62714:
-            case 65209:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-
-            // ALGALON
-            // Cosmic Smash (Algalon the Observer)
-            case 62293:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
-                break;
-            // Cosmic Smash (Algalon the Observer)
-            case 62311:
-            case 64596:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);  // 50000yd
-                break;
-            // Constellation Phase Effect
-            case 65509:
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-            // Black Hole
-            case 62168:
-            case 65250:
-            case 62169:
-                spellInfo->Attributes |= SPELL_ATTR0_NEGATIVE_1;
-                break;
-
-            // TRASH
-            // Ground Slam
-            case 62625:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                break;
-
-            //////////////////////////////////////////
-            ////////// ONYXIA'S LAIR
-            //////////////////////////////////////////
-            // Onyxia's Lair, Onyxia, Flame Breath (TriggerSpell = 0 and spamming errors in console)
-            case 18435:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            // Onyxia's Lair, Onyxia, Create Onyxia Spawner
-            case 17647:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(37);
-                break;
-            // Onyxia's Lair, Onyxia, Summon Onyxia Whelp
-            case 17646:
-            // Onyxia's Lair, Onyxia, Summon Lair Guard
-            case 68968:
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(5);
-                break;
-            // Onyxia's Lair, Onyxia, Eruption:
-            case 17731:
-            case 69294:
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
-                spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(3);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(19); // 18yd instead of 13yd to make sure all cracks erupt
-                break;
-            // Onyxia's Lair, Onyxia, Breath:
-            // TODO: fix it by IconId / SpellVisual
-            case 18576:
-            case 18578:
-            case 18579:
-            case 18580:
-            case 18581:
-            case 18582:
-            case 18583:
-            case 18609:
-            case 18611:
-            case 18612:
-            case 18613:
-            case 18614:
-            case 18615:
-            case 18616:
-            case 18584:
-            case 18585:
-            case 18586:
-            case 18587:
-            case 18588:
-            case 18589:
-            case 18590:
-            case 18591:
-            case 18592:
-            case 18593:
-            case 18594:
-            case 18595:
-            case 18564:
-            case 18565:
-            case 18566:
-            case 18567:
-            case 18568:
-            case 18569:
-            case 18570:
-            case 18571:
-            case 18572:
-            case 18573:
-            case 18574:
-            case 18575:
-            case 18596:
-            case 18597:
-            case 18598:
-            case 18599:
-            case 18600:
-            case 18601:
-            case 18602:
-            case 18603:
-            case 18604:
-            case 18605:
-            case 18606:
-            case 18607:
-            case 18617:
-            case 18619:
-            case 18620:
-            case 18621:
-            case 18622:
-            case 18623:
-            case 18624:
-            case 18625:
-            case 18626:
-            case 18627:
-            case 18628:
-            case 18618:
-            case 18351:
-            case 18352:
-            case 18353:
-            case 18354:
-            case 18355:
-            case 18356:
-            case 18357:
-            case 18358:
-            case 18359:
-            case 18360:
-            case 18361:
-            case 17086:
-            case 17087:
-            case 17088:
-            case 17089:
-            case 17090:
-            case 17091:
-            case 17092:
-            case 17093:
-            case 17094:
-            case 17095:
-            case 17097:
-            case 22267:
-            case 22268:
-            case 21132:
-            case 21133:
-            case 21135:
-            case 21136:
-            case 21137:
-            case 21138:
-            case 21139:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(328); // 250ms
-                spellInfo->Effects[EFFECT_1].TargetA = 1;
-                if( spellInfo->Effects[EFFECT_1].Effect )
-                {
-                    spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
-                    spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
-                    spellInfo->Effects[EFFECT_1].Amplitude = ((spellInfo->CastTimeEntry == sSpellCastTimesStore.LookupEntry(170)) ? 50 : 215);
-                }
-                break;
-
-            //////////////////////////////////////////
-            ////////// THE NEXUS: OCULUS
-            //////////////////////////////////////////
-            // Oculus, Teleport to Coldarra DND
-            case 48760:
-            // Oculus, Teleport to Boss 1 DND
-            case 49305:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(17);
-                break;
-            // Oculus, Drake spell Stop Time
-            case 49838:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                spellInfo->ExcludeTargetAuraSpell = 51162; // exclude planar shift
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_150_YARDS);
-                break;
-            // Oculus, Varos Cloudstrider, Energize Cores
-            case 61407:
-            case 62136:
-            case 56251:
-            case 54069:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-
-            //////////////////////////////////////////
-            ////////// HALLS OF LIGHTNING
-            //////////////////////////////////////////
-            // Halls of Lightning, Arc Weld
-            case 59086:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
-                break;
-            // Halls of Lightning, Arcing Burn
-            case 52671:
-            case 59834:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-
-            //////////////////////////////////////////
-            ////////// TRIAL OF THE CHAMPION
-            //////////////////////////////////////////
-            // Trial of the Champion, Death's Respite
-            case 68306:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
-                spellInfo->Effects[EFFECT_1].TargetA = 25;
-                break;
-            // Trial of the Champion, Eadric Achievement (The Faceroller)
-            case 68197:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
-                spellInfo->Attributes |= SPELL_ATTR0_CASTABLE_WHILE_DEAD;
-                break;
-            // Trial of the Champion, Earth Shield
-            case 67530:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL; // will trigger 67537
-                break;
-            // Trial of the Champion, Hammer of the Righteous
-            case 66867:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_DUMMY;
-                break;
-            // Trial of the Champion, Summon Risen Jaeren/Arelas
-            case 67705:
-            case 67715:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
-                break;
-            // Trial of the Champion, Ghoul Explode
-            case 67751:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(12);
-                break;
-            // Trial of the Champion, Desecration
-            case 67778:
-            case 67877:
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 68766;
-                break;
-
-            //////////////////////////////////////////
-            ////////// TRIAL OF THE CRUSADER
-            //////////////////////////////////////////
-            // Trial of the Crusader, Jaraxxus Intro spell
-            case 67888:
-                spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
-                spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // Trial of the Crusader, Lich King Intro spell
-            case 68193:
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
-                break;
-            // Trial of the Crusader, Gormok, player vehicle spell, CUSTOM! (default jump to hand, not used)
-            case 66342:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_SET_VEHICLE_ID;
-                spellInfo->Effects[EFFECT_0].MiscValue = 496;
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_CHANGE_MAP;
-                break;
-            // Trial of the Crusader, Gormok, Fire Bomb
-            case 66313:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                [[fallthrough]];
-            case 66317:
-                spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
-                spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            case 66318:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Speed = 14.0f;
-                spellInfo->Attributes |= SPELL_ATTR0_STOP_ATTACK_TARGET;
-                spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            case 66320:
-            case 67472:
-            case 67473:
-            case 67475:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(7);
-                break;
-            // Trial of the Crusader, Acidmaw & Dreadscale, Emerge
-            case 66947:
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
-                break;
-            // Trial of the Crusader, Jaraxxus, Curse of the Nether
-            case 66211:
-                spellInfo->ExcludeTargetAuraSpell = 66209; // exclude Touch of Jaraxxus
-                break;
-            // Trial of the Crusader, Jaraxxus, Summon Volcano
-            case 66258:
-            case 67901:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(85); // summon for 18 seconds, 15 not enough
-                break;
-            // Trial of the Crusader, Jaraxxus, Spinning Pain Spike
-            case 66281:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(26);
-                break;
-            case 66287:
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_TAUNT;
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_NEARBY_ENTRY;
-                spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_MOD_STUN;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35); // 4 secs
-                break;
-            // Trial of the Crusader, Jaraxxus, Fel Fireball
-            case 66532:
-            case 66963:
-            case 66964:
-            case 66965:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                break;
-            // tempfix, make Nether Power not stealable
-            case 66228:
-            case 67106:
-            case 67107:
-            case 67108:
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_NOT_STEALABLE;
-                break;
-            // Trial of the Crusader, Faction Champions, Druid - Tranquality
-            case 66086:
-            case 67974:
-            case 67975:
-            case 67976:
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AREA_AURA_FRIEND;
-                break;
-            // Trial of the Crusader, Faction Champions, Shaman - Earth Shield
-            case 66063:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PROC_TRIGGER_SPELL;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 66064;
-                break;
-            // Trial of the Crusader, Faction Champions, Priest - Mana Burn
-            case 66100:
-                spellInfo->Effects[EFFECT_0].BasePoints = 5;
-                spellInfo->Effects[EFFECT_0].DieSides = 0;
-                break;
-            case 68026:
-                spellInfo->Effects[EFFECT_0].BasePoints = 8;
-                spellInfo->Effects[EFFECT_0].DieSides = 0;
-                break;
-            case 68027:
-                spellInfo->Effects[EFFECT_0].BasePoints = 6;
-                spellInfo->Effects[EFFECT_0].DieSides = 0;
-                break;
-            case 68028:
-                spellInfo->Effects[EFFECT_0].BasePoints = 10;
-                spellInfo->Effects[EFFECT_0].DieSides = 0;
-                break;
-
-            // Trial of the Crusader, Twin Valkyr, Touch of Light/Darkness, Light/Dark Surge
-            case 65950: // light 0
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 65767: // light surge 0
-                spellInfo->ExcludeTargetAuraSpell = 65686;
-                break;
-            case 67296: // light 1
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67274: // light surge 1
-                spellInfo->ExcludeTargetAuraSpell = 67222;
-                break;
-            case 67297: // light 2
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67275: // light surge 2
-                spellInfo->ExcludeTargetAuraSpell = 67223;
-                break;
-            case 67298: // light 3
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67276: // light surge 3
-                spellInfo->ExcludeTargetAuraSpell = 67224;
-                break;
-            case 66001: // dark 0
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 65769: // dark surge 0
-                spellInfo->ExcludeTargetAuraSpell = 65684;
-                break;
-            case 67281: // dark 1
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67265: // dark surge 1
-                spellInfo->ExcludeTargetAuraSpell = 67176;
-                break;
-            case 67282: // dark 2
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67266: // dark surge 2
-                spellInfo->ExcludeTargetAuraSpell = 67177;
-                break;
-            case 67283: // dark 3
-                //spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                [[fallthrough]]; // TODO: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-            case 67267: // dark surge 3
-                spellInfo->ExcludeTargetAuraSpell = 67178;
-                break;
-
-            // Trial of the Crusader, Twin Valkyr, Twin's Pact
-            case 65875:
-            case 67303:
-            case 67304:
-            case 67305:
-            case 65876:
-            case 67306:
-            case 67307:
-            case 67308:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            // Trial of the Crusader, Anub'arak, Emerge
-            case 65982:
-                spellInfo->AttributesEx5 |= SPELL_ATTR5_USABLE_WHILE_STUNNED;
-                break;
-            // Trial of the Crusader, Anub'arak, Penetrating Cold
-            case 66013:
-            case 67700:
-            case 68509:
-            case 68510:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12); // 100yd
-                break;
-            // Trial of the Crusader, Anub'arak, Shadow Strike
-            case 66134:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                break;
-            // Trial of the Crusader, Anub'arak, Pursuing Spikes
-            case 65920:
-            case 65922:
-            case 65923:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_DUMMY;
-                //spellInfo->Effects[EFFECT_0].TriggerSpell = 0;
-                break;
-            // Trial of the Crusader, Anub'arak, Summon Scarab
-            case 66339:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(35);
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(25);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Trial of the Crusader, Anub'arak, Achievements: The Traitor King
-            case 68186: // Anub'arak Scarab Achievement 10
-            case 68515: // Anub'arak Scarab Achievement 25
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
-                spellInfo->Attributes |= SPELL_ATTR0_CASTABLE_WHILE_DEAD;
-                break;
-            // Trial of the Crusader, Anub'arak, Spider Frenzy
-            case 66129:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-
-            //////////////////////////////////////////
-            ////////// THE FORGE OF SOULS
-            //////////////////////////////////////////
-            // Soul Sickness (69131)
-            case 69131:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_PERIODIC_TRIGGER_SPELL;
-                spellInfo->Effects[EFFECT_0].Amplitude = 8000;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 69133;
-                break;
-            // Phantom Blast (68982,70322)
-            case 68982:
-            case 70322:
-                spellInfo->InterruptFlags |= SPELL_INTERRUPT_FLAG_INTERRUPT;
-                break;
-
-            //////////////////////////////////////////
-            ////////// PIT OF SARON
-            //////////////////////////////////////////
-            // Empowered Blizzard
-            case 70131:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            // Ice Lance Volley
-            case 70464:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENTRY);
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(25);
-                break;
-            // Multi-Shot
-            case 70513:
-            // Shriek of the Highborne
-            case 59514:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CONE_ENTRY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Icicle
-            case 69428:
-            case 69426:
-                spellInfo->InterruptFlags = 0;
-                spellInfo->AuraInterruptFlags = 0;
-                spellInfo->ChannelInterruptFlags = 0;
-                break;
-            // Jaina's Call
-            case 70525:
-            // Call of Sylvanas
-            case 70639:
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_SRC_CASTER;
-                spellInfo->Effects[EFFECT_2].TargetB = TARGET_UNIT_SRC_AREA_ENTRY;
-                spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(30); // 500yd
-                break;
-            // Frost Nova
-            case 68198:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                break;
-            // Blight
-            case 69604:
-            case 70286:
-                spellInfo->MaxAffectedTargets = 1;
-                spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
-                break;
-            // Chilling Wave
-            case 68778:
-            case 70333:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Permafrost
-            case 68786:
-            case 70336:
-                spellInfo->AttributesEx3 |= (SPELL_ATTR3_IGNORE_HIT_RESULT | SPELL_ATTR3_ONLY_TARGET_PLAYERS);
-                spellInfo->Effects[EFFECT_2].Effect = SPELL_EFFECT_DUMMY;
-                break;
-            // Pursuit:
-            case 68987:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_TARGET_ANY;
-                spellInfo->Effects[EFFECT_1].TargetB = 0;
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_CASTER;
-                spellInfo->Effects[EFFECT_2].TargetB = 0;
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            case 69029:
-            case 70850:
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            // Explosive Barrage:
-            case 69263:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_MOD_STUN;
-                break;
-            // Overlord's Brand:
-            case 69172:
-                spellInfo->ProcFlags = DONE_HIT_PROC_FLAG_MASK & ~PROC_FLAG_DONE_PERIODIC;
-                spellInfo->ProcChance = 100;
-                break;
-            // Icy Blast:
-            case 69232:
-                spellInfo->Effects[EFFECT_1].TriggerSpell = 69238;
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            case 69233:
-            case 69646:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            case 69238:
-            case 69628:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_DEST_DYNOBJ_NONE);
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // Hoarfrost:
-            case 69246:
-            case 69245:
-            case 69645:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // Devour Humanoid:
-            case 69503:
-                spellInfo->ChannelInterruptFlags |= 0;
-                spellInfo->AuraInterruptFlags = AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING;
-                break;
-
-            //////////////////////////////////////////
-            ////////// HALLS OF REFLECTION
-            //////////////////////////////////////////
-            // Falric: Defiling Horror
-            case 72435:
-            case 72452:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
-                break;
-            // Frostsworn General - Throw Shield
-            case 69222:
-            case 73076:
-                spellInfo->Effects[EFFECT_2].TargetA = TARGET_UNIT_TARGET_ENEMY;
-                break;
-            // Halls of Reflection Clone
-            case 69828:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            // Summon Ice Wall
-            case 69768:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            case 69767:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_TARGET_ANY);
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            // Essence of the Captured
-            case 73035:
-            case 70719:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);
-                break;
-            // Achievement Check
-            case 72830:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);
-                break;
-
-            //////////////////////////////////////////
-            ////////// ICECROWN CITADEL
-            //////////////////////////////////////////
-            case 70781: // Light's Hammer Teleport
-            case 70856: // Oratory of the Damned Teleport
-            case 70857: // Rampart of Skulls Teleport
-            case 70858: // Deathbringer's Rise Teleport
-            case 70859: // Upper Spire Teleport
-            case 70860: // Frozen Throne Teleport
-            case 70861: // Sindragosa's Lair Teleport
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB); // this target is for SPELL_EFFECT_TELEPORT_UNITS
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_2].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_2].TargetB = SpellImplicitTargetInfo();
-                break;
-            case 70960: // Bone Flurry
-            case 71258: // Adrenaline Rush (Ymirjar Battle-Maiden)
-                spellInfo->AttributesEx &= ~SPELL_ATTR1_CHANNELED_2;
-                break;
-            case 69055: // Saber Lash (Lord Marrowgar)
-            case 70814: // Saber Lash (Lord Marrowgar)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(8);    // 5yd
-                break;
-            case 69065: // Impaled (Lord Marrowgar)
-                spellInfo->Effects[EFFECT_0].Effect = 0; // remove stun so Dispersion can be used
-                break;
-            case 72701: // Cold Flame (Lord Marrowgar)
-            case 72702: // Cold Flame (Lord Marrowgar)
-            case 72703: // Cold Flame (Lord Marrowgar)
-            case 72704: // Cold Flame (Lord Marrowgar)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo();
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 secs instead of 12, need him for longer, but will stop his actions after 12 secs
-                break;
-            case 69138: // Coldflame (Lord Marrowgar)
-                spellInfo->Effects[EFFECT_0].Effect = 0;
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_DEST_DEST;
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 secs instead of 12, need him for longer, but will stop his actions after 12 secs
-                break;
-            case 69146:
-            case 70823:
-            case 70824:
-            case 70825: // Coldflame (Lord Marrowgar)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(15); // 3yd instead of 5yd
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-            case 70897: // Dark Martyrdom (Lady Deathwhisper)
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_DEAD;
-                break;
-            case 69075: // Bone Storm (Lord Marrowgar)
-            case 70834: // Bone Storm (Lord Marrowgar)
-            case 70835: // Bone Storm (Lord Marrowgar)
-            case 70836: // Bone Storm (Lord Marrowgar)
-            case 72378: // Blood Nova (Deathbringer Saurfang)
-            case 73058: // Blood Nova (Deathbringer Saurfang)
-            case 72769: // Scent of Blood (Deathbringer Saurfang)
-            case 72385: // Boiling Blood (Deathbringer Saurfang)
-            case 72441: // Boiling Blood (Deathbringer Saurfang)
-            case 72442: // Boiling Blood (Deathbringer Saurfang)
-            case 72443: // Boiling Blood (Deathbringer Saurfang)
-            case 71160: // Plague Stench (Stinky)
-            case 71161: // Plague Stench (Stinky)
-            case 71123: // Decimate (Stinky & Precious)
-            case 71464: // Divine Surge (Sister Svalna)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(12);   // 100yd
-                break;
-            case 71169: // Shadow's Fate
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            case 72347: // Lock Players and Tap Chest
-                spellInfo->AttributesEx3 &= ~SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            case 73843: // Award Reputation - Boss Kill
-            case 73844: // Award Reputation - Boss Kill
-            case 73845: // Award Reputation - Boss Kill
-            case 73846: // Award Reputation - Boss Kill
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);
-                break;
-            case 72864: // Death Plague (Rotting Frost Giant)
-                spellInfo->ExcludeTargetAuraSpell = 0;
-                break;
-            case 69705: // Gunship Battle, spell Below Zero
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            case 72723: // Resistant Skin (Deathbringer Saurfang adds)
-                // this spell initially granted Shadow damage immunity, however it was removed but the data was left in client
-                spellInfo->Effects[EFFECT_2].Effect = 0;
-                break;
-            case 72255: // Mark of the Fallen Champion (Deathbringer Saurfang) // Patch 3.3.2 (2010-01-02): Deathbringer Saurfang will no longer gain blood power from Mark of the Fallen Champion.
-            case 72444: // Mark of the Fallen Champion (Deathbringer Saurfang) // Xinef: prevented in script, effect needed for Prayer of Mending
-            case 72445: // Mark of the Fallen Champion (Deathbringer Saurfang)
-            case 72446: // Mark of the Fallen Champion (Deathbringer Saurfang)
-                spellInfo->AttributesEx3 &= ~SPELL_ATTR3_CANT_TRIGGER_PROC;
-                break;
-            case 70460: // Coldflame Jets (Traps after Saurfang)
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(1);   // 10 seconds
-                break;
-            case 70461: // Coldflame Jets (Traps after Saurfang)
-            case 71289: // Dominate Mind (Lady Deathwhisper)
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            case 71906: // Severed Essence (Val'kyr Herald)
-            case 71942: // Severed Essence (Val'kyr Herald)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            case 71159: // Awaken Plagued Zombies (Precious)
-            case 71302: // Awaken Ymirjar Fallen (Ymirjar Deathbringer)
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);
-                break;
-            case 70981: // Blood Prince Council, Invocation of Blood
-            case 70982: // Blood Prince Council, Invocation of Blood
-            case 70952: // Blood Prince Council, Invocation of Blood
-                spellInfo->Effects[EFFECT_0].Effect = 0; // clear share health aura
-                break;
-            case 71274: // Ymirjar Frostbinder, Frozen Orb
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(6);
-                break;
-            case 69783: // Ooze Flood (Rotface)
-            case 69797:
-            case 69799:
-            case 69802:
-                spellInfo->AttributesEx |= SPELL_ATTR1_CANT_TARGET_SELF;
-                break;
-            case 70530: // Volatile Ooze Beam Protection
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_APPLY_AURA; // blizzard typo, 65 instead of 6, aura itself is defined (dummy)
-                break;
-            case 70672:
-            case 72455:
-            case 72832:
-            case 72833: // Professor Putricide, Gaseous Bloat (Orange Ooze Channel) -- copied attributes from Green Ooze Channel
-                spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            case 71412: // Green Ooze Summon (Professor Putricide)
-            case 71415: // Orange Ooze Summon (Professor Putricide)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                break;
-            case 71621:
-            case 72850:
-            case 72851:
-            case 72852: // Create Concoction (Professor Putricide)
-            case 71893:
-            case 73120:
-            case 73121:
-            case 73122: // Guzzle Potions (Professor Putricide)
-                spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(15); // 4 sec
-                break;
-            case 72454: // Mutated Plague (Professor Putricide)
-            case 72464: // Mutated Plague (Professor Putricide)
-            case 72506: // Mutated Plague (Professor Putricide)
-            case 72507: // Mutated Plague (Professor Putricide)
-                spellInfo->AttributesEx4 |= SPELL_ATTR4_IGNORE_RESISTANCES;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 70911: // Unbound Plague (Professor Putricide) (needs target selection script)
-            case 72854: // Unbound Plague (Professor Putricide) (needs target selection script)
-            case 72855: // Unbound Plague (Professor Putricide) (needs target selection script)
-            case 72856: // Unbound Plague (Professor Putricide) (needs target selection script)
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
-                break;
-            case 70402: // Mutated Transformation (Professor Putricide)
-            case 72511: // Mutated Transformation (Professor Putricide)
-            case 72512: // Mutated Transformation (Professor Putricide)
-            case 72513: // Mutated Transformation (Professor Putricide)
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
-                break;
-            case 71708: // Empowered Flare (Blood Prince Council)
-            case 72785: // Empowered Flare (Blood Prince Council)
-            case 72786: // Empowered Flare (Blood Prince Council)
-            case 72787: // Empowered Flare (Blood Prince Council)
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            case 71518: // Unholy Infusion Quest Credit (Professor Putricide)
-            case 72934: // Blood Infusion Quest Credit (Blood-Queen Lana'thel)
-            case 72289: // Frost Infusion Quest Credit (Sindragosa)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // another missing radius
-                break;
-            case 71266: // Swarming Shadows
-            case 72890: // Swarming Shadows
-                spellInfo->AreaGroupId = 0; // originally, these require area 4522, which is... outside of Icecrown Citadel
-                break;
-            case 71301: // Summon Dream Portal (Valithria Dreamwalker)
-            case 71977: // Summon Nightmare Portal (Valithria Dreamwalker)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            case 70715: // Column of Frost (visual marker)
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(32); // 6 seconds (missing)
-                break;
-            case 71085: // Mana Void (periodic aura)
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(9); // 30 seconds (missing)
-                break;
-            case 70936: // Summon Suppressor (needs target selection script)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            case 70602: // Corruption
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
-                break;
-            case 72706: // Achievement Check (Valithria Dreamwalker)
-            case 71357: // Order Whelp
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                break;
-            case 70598: // Sindragosa's Fury
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 71077: // Tail Smash (Sindragosa)
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER_BACK);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
-                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_DEST_CASTER_BACK);
-                spellInfo->Effects[EFFECT_1].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_DEST_AREA_ENEMY);
-                break;
-            case 69846: // Frost Bomb
-                spellInfo->Speed = 0.0f;    // This spell's summon happens instantly
-                break;
-            case 70127: // Mystic Buffet (Sindragosa) - remove obsolete spell effect with no targets
-            case 72528:
-            case 72529:
-            case 72530:
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            case 70084: // Sindragosa, Frost Aura
-            case 71050:
-            case 71051:
-            case 71052:
-                spellInfo->Attributes &= ~SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                break;
-
-            case 71614: // Ice Lock
-                spellInfo->Mechanic = MECHANIC_STUN;
-                break;
-            case 70541: // Lich King, Infest
-            case 73779:
-            case 73780:
-            case 73781:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            case 70337: // Lich King, Necrotic Plague
-            case 73912:
-            case 73913:
-            case 73914:
-            case 70338:
-            case 73785:
-            case 73786:
-            case 73787:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            case 69099: // Ice Pulse 10n
-            case 73776: // Ice Pulse 25n
-            case 73777: // Ice Pulse 10h
-            case 73778: // Ice Pulse 25h
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CANT_CRIT;
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-            case 72350: // Fury of Frostmourne
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 72351: // Fury of Frostmourne
-            case 72431: // Jump (removes Fury of Frostmourne debuff)
-            case 72429: // Mass Resurrection
-            case 73159: // Play Movie
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 72376: // Raise Dead
-                spellInfo->MaxAffectedTargets = 4;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 71809: // Jump
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(5); // 40yd
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // 10yd
-                spellInfo->Effects[EFFECT_0].MiscValue = 190;
-                break;
-            case 72405: // Broken Frostmourne
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                break;
-            case 73540: // Summon Shadow Trap
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(3);          // 60 seconds
-                break;
-            case 73530: // Shadow Trap (visual)
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(28);          // 5 seconds
-                break;
-            case 73529: // Shadow Trap
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);   // 10yd
-                break;
-            case 74282: // Shadow Trap (searcher)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS);   // 3yd
-                break;
-            case 69198: // Raging Spirit Visual
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(13);             // 50000yd
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_IGNORE_HIT_RESULT;
-                break;
-            case 72762: // Defile
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(559); // 53 seconds
-                spellInfo->ExcludeCasterAuraSpell = 0;
-                spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                spellInfo->AttributesEx6 |= (SPELL_ATTR6_CAN_TARGET_INVISIBLE | SPELL_ATTR6_CAN_TARGET_UNTARGETABLE);
-                break;
-            case 72743: // Defile
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(22); // 45 seconds
-                break;
-            case 72754: // Defile
-            case 73708: // Defile
-            case 73709: // Defile
-            case 73710: // Defile
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                break;
-            case 69030: // Val'kyr Target Search
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
-                break;
-            case 73654: // Harvest Souls
-            case 74295: // Harvest Souls
-            case 74296: // Harvest Souls
-            case 74297: // Harvest Souls
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                spellInfo->Effects[EFFECT_2].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 72595: // Restore Soul
-            case 73650: // Restore Soul
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                break;
-            case 75127: // Kill Frostmourne Players
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            case 73655: // Harvest Soul
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_DONE_BONUS;
-                break;
-            case 74086: // Destroy Soul
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                break;
-            case 74302: // Summon Spirit Bomb
-            case 74342: // Summon Spirit Bomb
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                spellInfo->MaxAffectedTargets = 1;
-                break;
-            case 74341: // Summon Spirit Bomb
-            case 74343: // Summon Spirit Bomb
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS);   // 200yd
-                spellInfo->MaxAffectedTargets = 3;
-                break;
-            case 73579: // Summon Spirit Bomb
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS);   // 25yd
-                break;
-            case 73582: // Trigger Vile Spirit (Inside, Heroic)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS);   // 50000yd
-                break;
-            // Scale Aura (used during Dominate Mind from Lady Deathwhisper)
-            case 73261:
-                spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
-                break;
-            // Leap to a Random Location
-            case 70485:
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(6); // 100yd
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS);
-                spellInfo->Effects[EFFECT_0].MiscValue = 100;
-                break;
-            // Empowered Blood
-            case 70227:
-            case 70232:
-                spellInfo->AreaGroupId = 2452; // Whole icc instead of Crimson Halls only, remove when area calculation is fixed
-                break;
-
-            //////////////////////////////////////////
-            ////////// RUBY SANCTUN
-            //////////////////////////////////////////
-            // Repelling Wave
-            case 74509:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
-                break;
-            // Rallying Shout
-            case 75414:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS);
-                break;
-            // Barrier Channel
-            case 76221:
-                spellInfo->ChannelInterruptFlags &= ~(AURA_INTERRUPT_FLAG_TURNING | AURA_INTERRUPT_FLAG_MOVE);
-                spellInfo->Effects[EFFECT_0].TargetA = TARGET_UNIT_NEARBY_ENTRY;
-                break;
-            // Intimidating Roar
-            case 74384:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
-                break;
-            // Fiery Combustion
-            case 74562:
-            // Soul Consumption
-            case 74792:
-                spellInfo->AttributesEx |= SPELL_ATTR1_CANT_BE_REDIRECTED;
-                break;
-            // Combustion
-            case 75883:
-            case 75884:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
-                break;
-            // Consumption
-            case 75875:
-            case 75876:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_6_YARDS);
-                spellInfo->Effects[EFFECT_0].Mechanic = MECHANIC_NONE;
-                spellInfo->Effects[EFFECT_1].Mechanic = MECHANIC_SNARE;
-                break;
-            // Soul Consumption
-            case 74799:
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_12_YARDS);
-                break;
-            // Twilight Cutter
-            case 74769:
-            case 77844:
-            case 77845:
-            case 77846:
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
-                break;
-            // Twilight Mending
-            case 75509:
-                spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_100_YARDS);
-                break;
-            // Meteor Strike
-            case 74637:
-                spellInfo->Speed = 0;
-                break;
-            //Blazing Aura
-            case 75885:
-            case 75886:
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-            //Meteor Strike
-            case 75952:
-            //Combustion Periodic
-            case 74629:
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_IGNORE_RESISTANCES;
-                break;
-
-
-            // ///////////////////////////////////////////
-            // ////////////////QUESTS/////////////////////
-            // ///////////////////////////////////////////
-            // Going Bearback (12851)
-            case 54897:
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_DUMMY;
-                spellInfo->Effects[EFFECT_1].RadiusEntry = spellInfo->Effects[EFFECT_0].RadiusEntry;
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_DEST_AREA_ENTRY;
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
-                break;
-            // Still At It (12644)
-            case 51931:
-            case 51932:
-            case 51933:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(38);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo();
-                break;
-            // Rallying the Troops (12070)
-            case 47394:
-                spellInfo->ExcludeTargetAuraSpell = 47394;
-                break;
-            // A Tangled Skein (12555)
-            case 51165:
-            case 51173:
-                spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
-                break;
-            // A Cloudlet of Classy Cologne (24635)
-            case 69563:
-            // A Perfect Puff of Perfume (24629)
-            case 69445:
-            // Bonbon Blitz (24636)
-            case 69489:
-                spellInfo->Effects[EFFECT_1].TargetA = TARGET_UNIT_CASTER;
-                break;
-            // Control (9595)
-            case 30790:
-                spellInfo->Effects[EFFECT_1].MiscValue = 0;
-                break;
-            // Reclusive Runemaster (12150)
-            case 48028:
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_SRC_CASTER);
-                spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ENEMY);
-                break;
-            // Mastery of
-            case 65147:
-                spellInfo->CategoryEntry = sSpellCategoryStore.LookupEntry(1244);
-                spellInfo->CategoryRecoveryTime = 1500;
-                break;
-            // Weakness to Lightning (11896)
-            case 46432:
-                spellInfo->AttributesEx3 &= ~SPELL_ATTR3_DEATH_PERSISTENT;
-                break;
-            // Wrangle Some Aether Rays! (11065)
-            case 40856:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(27); // 3000ms
-                break;
-            // The Black Knight's Orders (13663)
-            case 63163:
-                spellInfo->Effects[EFFECT_0].BasePoints = 52390;
-                break;
-            // The Warp Rifts (10278)
-            case 34888:
-                spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(5); // 300 secs
-                break;
-            // The Smallest Creatures (10720)
-            case 38544:
-                spellInfo->Effects[EFFECT_0].MiscValueB = 427;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(1);
-                spellInfo->Effects[EFFECT_1].Effect = 0;
-                break;
-            // Ridding the red rocket
-            case 49177:
-                spellInfo->Effects[EFFECT_0].BasePoints = 1; // corrects seat id (points - 1 = seatId)
-                break;
-            // The Iron Colossus (13007)
-            case 56513:
-            case 56524:
-                spellInfo->RecoveryTime = (spellInfo->Id == 56524 ? 6000 : 2000);
-                break;
-            // Kaw the Mammoth Destroyer (11879)
-            case 46260:
-                spellInfo->AttributesEx2 |= SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS;
-                break;
-            // That's Abominable (13264)(13276)(13288)(13289)
-            case 59565:
-                spellInfo->Effects[EFFECT_0].MiscValueB = 1721; // controlable guardian
-                break;
-            // Investigate the Blue Recluse (1920)
-            // Investigate the Alchemist Shop (1960)
-            case 9095:
-                spellInfo->Effects[EFFECT_0].ApplyAuraName = SPELL_AURA_DUMMY;
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(13);
-                break;
-            // Dragonmaw Race: All parts
-            case 40890: // Oldie's Rotten Pumpkin
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 40909: // Trope's Slime Cannon
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 40905;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 40894: // Corlok's Skull Barrage
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 40900;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 40928: // Ichman's Blazing Fireball
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 40929;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 40930: // Mulverick's Great Balls of Lightning
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 40931;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            case 40945: // Sky Shatter
-                spellInfo->Targets |= TARGET_FLAG_DEST_LOCATION;
-                spellInfo->Effects[EFFECT_0].TriggerSpell = 41064;
-                spellInfo->Effects[EFFECT_0].Effect = SPELL_EFFECT_TRIGGER_MISSILE;
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-                break;
-            // Gauging the Resonant Frequency (10594)
-            case 37390:
-                spellInfo->Effects[EFFECT_0].MiscValueB = 181;
-                break;
-            // Where in the World is Hemet Nesingwary? (12521)
-            case 50860:
-                spellInfo->Effects[EFFECT_0].BasePoints = 50860;
-                break;
-            case 50861:
-                spellInfo->Effects[EFFECT_0].BasePoints = 0;
-                break;
-            // Krolmir, Hammer of Storms (13010)
-            case 56606:
-            case 56541:
-                spellInfo->Effects[EFFECT_0].BasePoints = 1;
-                break;
-            // Blightbeasts be Damned! (12072)
-            case 47424:
-                spellInfo->AuraInterruptFlags &= ~AURA_INTERRUPT_FLAG_NOT_ABOVEWATER;
-                break;
-            // Leading the Charge (13380), All Infra-Green bomber quests
-            case 59059:
-                spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
-                break;
             // Dark Horizon (12664), Reunited (12663)
             case 52190:
                 spellInfo->Effects[EFFECT_0].BasePoints = 52391 - 1;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3495,6 +3495,60 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].Amplitude = 3000;
     });
 
+    // Desecration Arm - 36 instead of 37 - typo? :/
+    ApplySpellFix({ 29809 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(37);
+    });
+
+    // Sic'em
+    ApplySpellFix({ 42767 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
+    });
+
+    // Master Shapeshifter: missing stance data for forms other than bear - bear version has correct data
+    // To prevent aura staying on target after talent unlearned
+    ApplySpellFix({ 48420 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Stances = 1 << (FORM_CAT - 1);
+    });
+
+    ApplySpellFix({ 48421 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Stances = 1 << (FORM_MOONKIN - 1);
+    });
+
+    ApplySpellFix({ 48422 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Stances = 1 << (FORM_TREE - 1);
+    });
+
+    // Elemental Oath
+    ApplySpellFix({
+        51466, // Elemental Oath (Rank 1)
+        51470  // Elemental Oath (Rank 2)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+        spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
+        spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_EFFECT2;
+        spellInfo->Effects[EFFECT_1].SpellClassMask = flag96(0x00000000, 0x00004000, 0x00000000);
+    });
+
+    // Improved Shadowform (Rank 1)
+    ApplySpellFix({ 47569 }, [](SpellInfo* spellInfo)
+    {
+        // with this spell atrribute aura can be stacked several times
+        spellInfo->Attributes &= ~SPELL_ATTR0_NOT_SHAPESHIFT;
+    });
+
+    // Nether Portal - Perseverence
+    ApplySpellFix({ 30421 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].BasePoints += 30000;
+    });
+
     for (auto spellInfo : mSpellInfoMap)
     {
         for (uint8 j = 0; j < MAX_SPELL_EFFECTS; ++j)
@@ -3530,37 +3584,6 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         switch (spellInfo->Id)
         {
-            case 29809: // Desecration Arm - 36 instead of 37 - typo? :/
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(37);
-                break;
-            case 42767: // Sic'em
-                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
-                break;
-            // Master Shapeshifter: missing stance data for forms other than bear - bear version has correct data
-            // To prevent aura staying on target after talent unlearned
-            case 48420:
-                spellInfo->Stances = 1 << (FORM_CAT - 1);
-                break;
-            case 48421:
-                spellInfo->Stances = 1 << (FORM_MOONKIN - 1);
-                break;
-            case 48422:
-                spellInfo->Stances = 1 << (FORM_TREE - 1);
-                break;
-            case 51466: // Elemental Oath (Rank 1)
-            case 51470: // Elemental Oath (Rank 2)
-                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
-                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-                spellInfo->Effects[EFFECT_1].MiscValue = SPELLMOD_EFFECT2;
-                spellInfo->Effects[EFFECT_1].SpellClassMask = flag96(0x00000000, 0x00004000, 0x00000000);
-                break;
-            case 47569: // Improved Shadowform (Rank 1)
-                // with this spell atrribute aura can be stacked several times
-                spellInfo->Attributes &= ~SPELL_ATTR0_NOT_SHAPESHIFT;
-                break;
-            case 30421: // Nether Portal - Perseverence
-                spellInfo->Effects[EFFECT_2].BasePoints += 30000;
-                break;
             case 16834: // Natural shapeshifter
             case 16835:
                 spellInfo->DurationEntry = sSpellDurationStore.LookupEntry(21);

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -733,8 +733,8 @@ public:
     void LoadSpellInfoStore();
     void UnloadSpellInfoStore();
     void UnloadSpellInfoImplicitTargetConditionLists();
-    void LoadSpellCustomAttr();
-    void LoadDbcDataCorrections();
+    void LoadSpellInfoCustomAttributes();
+    void LoadSpellInfoCorrections();
     void LoadSpellSpecificAndAuraState();
 
 private:

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -970,11 +970,11 @@ void World::SetInitialWorldSettings()
     LOG_INFO("server.loading", "Loading Game Graveyard...");
     sGraveyard->LoadGraveyardFromDB();
 
-    LOG_INFO("server.loading", "Loading spell dbc data corrections...");
-    sSpellMgr->LoadDbcDataCorrections();
-
     LOG_INFO("server.loading", "Loading SpellInfo store...");
     sSpellMgr->LoadSpellInfoStore();
+
+    LOG_INFO("server.loading", "Loading SpellInfo corrections...");
+    sSpellMgr->LoadSpellInfoCorrections();
 
     LOG_INFO("server.loading", "Loading Spell Rank Data...");
     sSpellMgr->LoadSpellRanks();
@@ -985,8 +985,8 @@ void World::SetInitialWorldSettings()
     LOG_INFO("server.loading", "Loading SkillLineAbilityMultiMap Data...");
     sSpellMgr->LoadSkillLineAbilityMap();
 
-    LOG_INFO("server.loading", "Loading spell custom attributes...");
-    sSpellMgr->LoadSpellCustomAttr();
+    LOG_INFO("server.loading", "Loading SpellInfo custom attributes...");
+    sSpellMgr->LoadSpellInfoCustomAttributes();
 
     LOG_INFO("server.loading", "Loading GameObject models...");
     LoadGameObjectModelList(m_dataPath);


### PR DESCRIPTION
- Operate spell correction on SpellInfo store instead of dbc
- Refactor setting spell info corrections to report errors about spells that no longer exist